### PR TITLE
Replace smoke scripts with real tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration for making the project package importable."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_ea_logger.py
+++ b/tests/test_ea_logger.py
@@ -1,59 +1,48 @@
-# tests/test_ea_logger.py
+"""Tests for TrainingLogger utility used by the evolutionary search."""
+from __future__ import annotations
+
+import json
 from pathlib import Path
-import sys
 
-# make project root (that contains /src and /tests) importable
-ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+import pytest
 
-from datetime import date
-from src.optimization.evolutionary import evolutionary_search
-from src.utils.progress import console_progress
+from src.utils.training_logger import TrainingLogger
 
 
-if __name__ == "__main__":
-    # Narrow param space for a quick smoke run
-    param_space = {
-        "breakout_n": (10, 15),
-        "exit_n": (5, 8),
-        "atr_n": (10, 14),
-        "atr_multiple": (1.5, 2.5),
-        "tp_multiple": (0.0, 1.0),
-        "holding_period_limit": (0, 5),
-    }
+def test_training_logger_appends_json_lines(tmp_path: Path) -> None:
+    path = tmp_path / "log.jsonl"
+    logger = TrainingLogger(path)
 
-    results = evolutionary_search(
-        strategy_dotted="src.models.atr_breakout",
-        tickers=["AAPL"],  # must exist in your data loader
-        start=date(2020, 1, 1),
-        end=date(2021, 1, 1),
-        starting_equity=10000.0,
-        param_space=param_space,
-        generations=2,
-        pop_size=6,
-        # EA diversity
-        mutation_rate=0.5,
-        elite_frac=0.5,
-        random_inject_frac=0.2,
-        # Fitness gates
-        min_trades=3,
-        require_hold_days=False,
-        eps_mdd=1e-4,
-        eps_sharpe=1e-4,
-        # Fitness weights (growth vs risk)
-        alpha_cagr=1.0,
-        beta_calmar=1.0,
-        gamma_sharpe=0.25,
-        # Holding window preference (avoid day trades; avoid buy/hold)
-        min_holding_days=3.0,
-        max_holding_days=30.0,
-        holding_penalty_weight=0.1,
-        # Progress & logs
-        progress_cb=console_progress,
-        log_file="ea_test.log",
-    )
+    logger.log("generation_start", {"gen": 0, "pop_size": 4})
+    logger.log("individual_evaluated", {"score": 1.23})
 
-    print("\nTop results:")
-    for params, score in results:
-        print(f"Score={score:.3f} Params={params}")
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+
+    records = [json.loads(line) for line in lines]
+    assert records[0]["event"] == "generation_start"
+    assert records[0]["payload"] == {"gen": 0, "pop_size": 4}
+    assert "ts" in records[0]
+    assert records[1]["event"] == "individual_evaluated"
+
+
+def test_training_logger_records_errors(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    path = tmp_path / "errors.jsonl"
+    logger = TrainingLogger(path)
+
+    class BoomError(RuntimeError):
+        pass
+
+    with caplog.at_level("ERROR"):
+        logger.log_error({"gen": 1}, BoomError("failed"))
+
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+
+    record = json.loads(lines[0])
+    assert record["event"] == "error"
+    assert record["payload"]["context"] == {"gen": 1}
+    assert record["payload"]["error_type"] == "BoomError"
+    assert record["payload"]["error_msg"] == "failed"
+
+    assert any("BoomError" in msg for msg in caplog.text.splitlines())

--- a/tests/test_strategy_adapter_pipeline.py
+++ b/tests/test_strategy_adapter_pipeline.py
@@ -1,435 +1,110 @@
-# tests/test_strategy_adapter_pipeline.py
+"""Tests covering the strategy adapter pipeline pieces."""
 from __future__ import annotations
 
-import os
-import sys
-from datetime import datetime, timedelta, UTC
-from pathlib import Path
-from typing import Any, Dict, List, Tuple
+import types
+from datetime import datetime, timedelta
+from typing import Any, Dict
 
 import pandas as pd
+import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-# What we will validate after we compute metrics locally
-REQUIRED_METRIC_KEYS = {
-    "trades",
-    "total_return",
-    "cagr",
-    "max_drawdown",
-    "calmar",
-    "sharpe",
-    "profit_factor",
-    "expectancy",
-}
-
-STRATEGY_DOTTED = os.getenv("STRATEGY_DOTTED", "src.models.atr_breakout")
-TICKERS = [t.strip() for t in os.getenv("STRAT_TEST_TICKERS", "AAPL,MSFT").split(",") if t.strip()]
-DAYS_BACK = int(os.getenv("STRAT_TEST_DAYS", "365"))
-STARTING_EQUITY = float(os.getenv("STRAT_TEST_EQUITY", "10000"))
-PORTFOLIO_NAME = os.getenv("STRAT_TEST_PORTFOLIO", "")
-
-BASE_PARAMS: Dict[str, Any] = {
-    "breakout_n": 14,
-    "exit_n": 6,
-    "atr_n": 14,
-    "atr_multiple": 2.0,
-    "tp_multiple": 0.5,
-    "holding_period_limit": 5,
-    # extras in UI—filtered out to match ATRParams when calling run_strategy:
-    "use_trend_filter": False,
-    "sma_fast": 20,
-    "sma_slow": 50,
-    "sma_long": 200,
-    "long_slope_len": 20,
-    "risk_per_trade": 0.005,
-    "cost_bps": 1.0,
-    "execution": "close",
-}
-
-EA_SPACE: Dict[str, Tuple] = {
-    "breakout_n": (10, 20),
-    "exit_n": (5, 10),
-    "atr_n": (10, 20),
-    "atr_multiple": (1.2, 2.5),
-    "tp_multiple": (0.2, 0.8),
-    "holding_period_limit": (2, 8),
-}
-EA_GENERATIONS = int(os.getenv("EA_TEST_GENERATIONS", "2"))
-EA_POP = int(os.getenv("EA_TEST_POP", "6"))
-EA_MIN_TRADES = int(os.getenv("EA_TEST_MIN_TRADES", "1"))
-EA_NJOBS = int(os.getenv("EA_TEST_NJOBS", "1"))
+from src.models import general_trainer
 
 
-def banner(title: str):
-    print("\n" + "=" * 72)
-    print(title)
-    print("=" * 72)
+@pytest.fixture
+def stub_strategy_module(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Create a fake strategy module with a deterministic run_strategy."""
+    module_name = "tests.fake_strategy"
+    mod = types.ModuleType(module_name)
 
-
-def leg(title: str, fn, *args, **kwargs):
-    print("\n" + "-" * 72)
-    print(title)
-    print("-" * 72)
-    try:
-        out = fn(*args, **kwargs)
-        print("RESULT: PASS")
-        return True, out
-    except Exception as e:
-        print("RESULT: FAIL")
-        print("ERROR :", repr(e))
-        return False, e
-
-def df_info(df: pd.DataFrame | pd.Series, name: str):
-    # Avoid pandas truthiness; check emptiness via attribute
-    if df is None:
-        print(f"{name}: <None>")
-        return
-    is_empty = getattr(df, "empty", None)
-    if is_empty is True:
-        print(f"{name}: EMPTY")
-        return
-
-    try:
-        if isinstance(df, pd.Series):
-            print(f"{name}: rows={len(df)} index={type(df.index).__name__}")
-        else:
-            print(f"{name}: rows={len(df)} cols={list(df.columns)} index={type(df.index).__name__}")
-        print("  head:", df.index[0], "tail:", df.index[-1])
-    except Exception:
-        # Keep this non-fatal—diagnostic only
-        pass
-
-def assert_metrics_contract(metrics: Dict[str, Any]):
-    missing = [k for k in REQUIRED_METRIC_KEYS if k not in metrics]
-    if missing:
-        raise AssertionError(f"metrics missing required keys: {missing}")
-    for k in ["trades", "total_return", "cagr", "max_drawdown", "calmar", "sharpe", "profit_factor", "expectancy"]:
-        v = metrics.get(k)
-        if not isinstance(v, (int, float)):
-            raise AssertionError(f"metrics['{k}'] should be numeric, got {type(v).__name__}")
-    if metrics["trades"] < 0:
-        raise AssertionError("metrics['trades'] must be >= 0")
-
-
-def leg_env():
-    banner("Environment")
-    print("Python:", sys.version.split()[0], f"({sys.executable})")
-    print("PWD   :", os.getcwd())
-    print("ROOT  :", ROOT)
-    print("Strategy dotted:", STRATEGY_DOTTED)
-    print("Tickers        :", TICKERS)
-    print("Days back      :", DAYS_BACK)
-    print("Starting equity:", STARTING_EQUITY)
-    print("Portfolio name :", PORTFOLIO_NAME or "<none>")
-
-
-def leg_imports():
-    import importlib
-    banner("Import modules")
-    L = importlib.import_module("src.data.loader")
-    S = importlib.import_module(STRATEGY_DOTTED)
-    GT = importlib.import_module("src.models.general_trainer")
-    EV = importlib.import_module("src.optimization.evolutionary")
-    M = importlib.import_module("src.backtest.metrics")
-    print("\n" + "=" * 72)
-    print("Module paths")
-    print("=" * 72)
-    print("loader file   :", getattr(L, "__file__", "<??>"))
-    print("strategy file :", getattr(S, "__file__", "<??>"))
-    print("trainer file  :", getattr(GT, "__file__", "<??>"))
-    print("evolutionary  :", getattr(EV, "__file__", "<??>"))
-    print("metrics file  :", getattr(M, "__file__", "<??>"))
-    return L, S, GT, EV, M
-
-
-def _filter_params_for_strategy(S, base: Dict[str, Any]) -> Dict[str, Any]:
-    params = dict(base)
-
-    default_params = getattr(S, "DEFAULT_PARAMS", None)
-    if isinstance(default_params, dict) and default_params:
-        allowed = set(default_params.keys())
-        filtered = {k: params.get(k, v) for k, v in default_params.items()}
-        print(f"Using DEFAULT_PARAMS keys from strategy: {sorted(allowed)}")
-        return filtered
-
-    P = getattr(S, "ATRParams", None)
-    allowed_keys = None
-    if P is not None:
-        try:
-            from dataclasses import is_dataclass, fields
-            if is_dataclass(P):
-                allowed_keys = {f.name for f in fields(P)}
-        except Exception:
-            pass
-        if allowed_keys is None:
-            allowed_keys = set(getattr(P, "__annotations__", {}).keys()) or None
-        if allowed_keys is None:
-            mf = getattr(P, "model_fields", None)
-            if isinstance(mf, dict) and mf:
-                allowed_keys = set(mf.keys())
-        if allowed_keys is None:
-            fld = getattr(P, "__fields__", None)
-            if isinstance(fld, dict) and fld:
-                allowed_keys = set(fld.keys())
-
-    if allowed_keys:
-        print(f"Allowed ATRParams keys discovered: {sorted(allowed_keys)}")
-        return {k: v for k, v in params.items() if k in allowed_keys}
-
-    core = {"breakout_n", "exit_n", "atr_n", "atr_multiple", "tp_multiple", "holding_period_limit"}
-    print("WARNING: Could not introspect ATRParams; using conservative param subset.")
-    return {k: v for k, v in params.items() if k in core}
-
-
-def leg_data_load(L):
-    banner("Unified data load via loader.get_ohlcv")
-    end = datetime.now(UTC)
-    start = end - timedelta(days=DAYS_BACK)
-    data: Dict[str, pd.DataFrame] = {}
-    for sym in TICKERS:
-        ok, out = leg(f"LOAD {sym}", getattr(L, "get_ohlcv"), sym, start, end)
-        if not ok:
-            raise out
-        df = out
-        df_info(df, sym)
-        cols = {c.lower() for c in df.columns}
-        for need in ("open", "high", "low", "close"):
-            if need not in cols:
-                raise AssertionError(f"{sym}: loader did not provide required column '{need}'")
-        data[sym] = df
-    return start, end, data
-
-
-def _retry_strip_kwargs(callable_fn, sym, start, end, equity, params: Dict[str, Any], max_retries: int = 6):
-    p = dict(params)
-    for i in range(max_retries + 1):
-        try:
-            return callable_fn(sym, start, end, equity, p)
-        except TypeError as e:
-            msg = str(e)
-            marker = "unexpected keyword argument"
-            if marker in msg:
-                bad = None
-                if "'" in msg:
-                    try:
-                        bad = msg.split("'")[1]
-                    except Exception:
-                        bad = None
-                if bad and bad in p:
-                    print(f"[retry {i+1}] removing unsupported param: {bad}")
-                    p.pop(bad, None)
-                    continue
-            raise
-    raise RuntimeError("Exceeded max_retries while stripping unexpected kwargs.")
-
-
-def leg_strategy_run(S, M, start, end):
-    import pandas as pd
-
-    banner("Strategy.run_strategy() exact contract")
-    run = getattr(S, "run_strategy", None)
-    if run is None:
-        raise AttributeError(f"{STRATEGY_DOTTED} is missing run_strategy")
-
-    params = _filter_params_for_strategy(S, BASE_PARAMS)
-    print("Params passed to run_strategy:", sorted(params.keys()))
-
-    def _safe_len(x):
-        try:
-            return len(x)
-        except Exception:
-            return "??"
-
-    summaries = {}
-    for sym in TICKERS:
-        ok, out = leg(
-            f"RUN run_strategy on {sym}",
-            _retry_strip_kwargs,
-            run,
-            sym,
-            start,
-            end,
-            STARTING_EQUITY,
-            params,
+    def run_strategy(symbol: str, start: datetime, end: datetime, equity: float, params: Dict[str, Any]) -> Dict[str, Any]:
+        # simple deterministic equity curve: start at equity, +1% per day
+        idx = pd.date_range(start, end, freq="D")
+        if len(idx) < 2:
+            idx = pd.date_range(start, periods=2, freq="D")
+        curve = pd.Series(
+            [equity * (1 + 0.01 * i) for i in range(len(idx))],
+            index=idx,
         )
-        if not ok:
-            raise out
-        if not isinstance(out, dict):
-            raise AssertionError(f"{sym}: run_strategy should return dict, got {type(out).__name__}")
+        daily_returns = curve.pct_change().fillna(0.0)
+        trades = [
+            {
+                "return_pct": 0.02,
+                "holding_days": 2,
+                "mfe": 0.03,
+                "mae": -0.01,
+                "side": "long",
+                "entry_price": 100.0,
+                "exit_price": 102.0,
+                "day_low": 99.0,
+                "day_high": 103.0,
+                "day_low_exit": 100.0,
+                "day_high_exit": 104.0,
+            }
+        ]
+        return {
+            "equity": curve,
+            "daily_returns": daily_returns,
+            "trades": trades,
+            "meta": {"symbol": symbol, "param_keys": sorted(params.keys())},
+        }
 
-        equity = out.get("equity")
-        trades = out.get("trades")
-        daily = out.get("daily_returns")
-
-        # ---- Type/shape guards (never rely on pandas truthiness) ----
-        if not isinstance(equity, pd.Series):
-            # tolerate a 1-col DataFrame by squeezing
-            if hasattr(equity, "squeeze"):
-                equity = equity.squeeze()
-            if not isinstance(equity, pd.Series):
-                raise TypeError(f"{sym}: 'equity' should be a pandas Series, got {type(equity).__name__}")
-
-        if daily is not None and not isinstance(daily, pd.Series):
-            if hasattr(daily, "squeeze"):
-                daily = daily.squeeze()
-            if not isinstance(daily, pd.Series):
-                raise TypeError(f"{sym}: 'daily_returns' should be Series or None, got {type(daily).__name__}")
-
-        # Derive daily if missing/empty (no boolean evaluation of Series)
-        derive_daily = (daily is None) or (getattr(daily, "empty", False) is True)
-        if derive_daily:
-            daily = equity.pct_change().fillna(0.0)
-
-        # ---- Sanity prints (no boolean checks on pandas objects) ----
-        df_info(equity, f"{sym}.equity")
-        print(f"{sym}.trades: {type(trades).__name__} len={_safe_len(trades)}")
-        df_info(daily, f"{sym}.daily_returns")
-
-        # ---- Compute metrics using your backtest.metrics ----
-        compute = getattr(M, "compute_core_metrics", None)
-        if compute is None:
-            raise AttributeError("src.backtest.metrics missing compute_core_metrics()")
-
-        metrics = compute(equity=equity, daily_returns=daily, trades=trades)
-        assert_metrics_contract(metrics)
-        print(
-            f"{sym}: trades={metrics.get('trades')} "
-            f"total_return={float(metrics.get('total_return', 0.0)):.4f} "
-            f"sharpe={float(metrics.get('sharpe', 0.0)):.3f}"
-        )
-        summaries[sym] = metrics
-
-    return summaries
-
-def leg_general_trainer(GT, start, end, tickers, S):
-    banner("General Trainer (portfolio CV) — optional")
-    train = getattr(GT, "train_general_model", None)
-    if train is None:
-        raise AttributeError("src.models.general_trainer missing train_general_model")
-
-    params_for_strat = _filter_params_for_strategy(S, BASE_PARAMS)
-    ok, res = leg(
-        f"train_general_model on tickers={tickers}",
-        train,
-        STRATEGY_DOTTED,          # strategy_dotted: str
-        tickers,                  # tickers: List[str]
-        start,                    # start
-        end,                      # end
-        STARTING_EQUITY,          # starting_equity: float
-        params_for_strat,         # base_params: Dict[str, Any]
-    )
-    if not ok:
-        raise res
-    if not isinstance(res, dict):
-        raise AssertionError(f"train_general_model should return dict, got {type(res).__name__}")
-
-    # Validate structure per your docstring
-    for key in ("strategy", "params", "period", "results", "aggregate"):
-        if key not in res:
-            raise AssertionError(f"train_general_model missing key '{key}'")
-
-    agg = res.get("aggregate", {}) or {}
-    if "metrics" not in agg:
-        raise AssertionError("aggregate missing 'metrics'")
-    print("aggregate.metrics keys:", sorted(list(agg.get("metrics", {}).keys()))[:12], "...")
-
-    print("trainer.results rows:", len(res.get("results", [])))
-    return res
+    mod.run_strategy = run_strategy  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, mod)
+    return module_name
 
 
-def leg_evolutionary(EV, start, end):
-    banner("Evolutionary Search — smoke test")
-    evo = getattr(EV, "evolutionary_search", None)
-    if evo is None:
-        raise AttributeError("src.optimization.evolutionary missing evolutionary_search")
-    ok, top = leg(
-        f"evolutionary_search on {TICKERS}",
-        evo,
-        STRATEGY_DOTTED,
-        TICKERS,
+@pytest.fixture
+def sample_period() -> tuple[datetime, datetime]:
+    start = datetime(2024, 1, 1)
+    end = start + timedelta(days=4)
+    return start, end
+
+
+def test_train_general_model_aggregates_metrics(stub_strategy_module: str, sample_period: tuple[datetime, datetime]) -> None:
+    start, end = sample_period
+    tickers = ["AAPL", "MSFT"]
+    params = {"breakout_n": 14}
+
+    report = general_trainer.train_general_model(
+        stub_strategy_module,
+        tickers,
         start,
         end,
-        STARTING_EQUITY,
-        EA_SPACE,
-        generations=EA_GENERATIONS,
-        pop_size=EA_POP,
-        mutation_rate=0.4,
-        elite_frac=0.5,
-        random_inject_frac=0.2,
-        n_jobs=EA_NJOBS,
-        min_trades=EA_MIN_TRADES,
-        # gates & clamps
-        min_avg_holding_days_gate=1.0,
-        require_hold_days=False,
-        eps_mdd=1e-4,
-        eps_sharpe=1e-4,
-        # fitness weights
-        alpha_cagr=1.0,
-        beta_calmar=1.0,
-        gamma_sharpe=0.25,
-        # holding preferences
-        min_holding_days=3.0,
-        max_holding_days=30.0,
-        holding_penalty_weight=1.0,
-        # trade-rate preferences (per symbol per year)
-        trade_rate_min=5.0,
-        trade_rate_max=50.0,
-        trade_rate_penalty_weight=0.5,
-        # plumbing
-        progress_cb=lambda *_a, **_k: None,
-        log_file="training.log",
-        seed=None,
+        starting_equity=10_000.0,
+        base_params=params,
     )
-    if not ok:
-        raise top
-    if not isinstance(top, list) or len(top) == 0:
-        raise AssertionError("evolutionary_search returned empty leaderboard or wrong type")
-    p0, s0 = top[0]
-    if not isinstance(p0, dict) or not isinstance(s0, (int, float)):
-        raise AssertionError("leaderboard[0] should be (Dict[str, Any], float)")
-    print("EA top[0]: score=", round(float(s0), 3), "params=", {k: p0.get(k) for k in list(EA_SPACE.keys())})
-    return top
+
+    assert report["strategy"] == stub_strategy_module
+    assert report["params"] == params
+    assert set(report["period"].keys()) == {"start", "end"}
+    assert len(report["results"]) == len(tickers)
+
+    aggregate = report["aggregate"]["metrics"]
+    # Each symbol contributes one trade, so aggregate trades should equal len(tickers)
+    assert aggregate["trades"] == len(tickers)
+    # Weighted averages should stay within reasonable bounds
+    assert 0.0 <= aggregate["avg_holding_days"] <= 2.0
+    assert 0.0 <= aggregate["win_rate"] <= 1.0
+    assert aggregate["expectancy"] != 0.0
+    # Core performance metrics should be present
+    for key in ["total_return", "cagr", "max_drawdown", "calmar", "sharpe"]:
+        assert key in aggregate
 
 
-def main() -> int:
-    banner("Environment")
-    print("Python:", sys.version.split()[0], f"({sys.executable})")
-    print("PWD   :", os.getcwd())
-    print("ROOT  :", ROOT)
-    print("Strategy dotted:", STRATEGY_DOTTED)
-    print("Tickers        :", TICKERS)
-    print("Days back      :", DAYS_BACK)
-    print("Starting equity:", STARTING_EQUITY)
-    print("Portfolio name :", PORTFOLIO_NAME or "<none>")
+def test_import_callable_validates_presence(monkeypatch: pytest.MonkeyPatch) -> None:
+    module_name = "tests.empty_strategy"
+    empty_module = types.ModuleType(module_name)
+    monkeypatch.setitem(sys.modules, module_name, empty_module)
 
-    ok, mods = leg("Import modules", leg_imports)
-    if not ok:
-        return 1
-    L, S, GT, EV, M = mods
-
-    ok, se = leg("Load data (all tickers)", leg_data_load, L)
-    if not ok:
-        return 1
-    start, end, _ = se
-
-    ok, _summ = leg("Strategy.run_strategy()", leg_strategy_run, S, M, start, end)
-    if not ok:
-        return 1
-
-    ok, _tr = leg("General Trainer (optional)", leg_general_trainer, GT, start, end, TICKERS, S)
-    if not ok:
-        return 1
-
-    ok, _ea = leg("Evolutionary Search (smoke)", leg_evolutionary, EV, start, end)
-    if not ok:
-        return 1
-
-    banner("All strategy adapter pipeline legs completed.")
-    return 0
+    with pytest.raises(ImportError):
+        general_trainer.import_callable(module_name)
 
 
-if __name__ == "__main__":
-    raise SystemExit(main())
+def test_weighted_average_handles_empty_inputs() -> None:
+    assert general_trainer._weighted_average([], []) == 0.0
+    assert general_trainer._weighted_average([1.0, 2.0], [0.0, 0.0]) == 0.0
+
+
+# Need sys imported for monkeypatching sys.modules
+import sys  # placed at end to avoid circular import issues in fixtures

--- a/tests/test_walkforward.py
+++ b/tests/test_walkforward.py
@@ -1,315 +1,86 @@
-# tests/test_walkforward.py
+"""Tests targeting evolutionary search helpers (fitness & sampling)."""
 from __future__ import annotations
 
-import os
-import sys
-import importlib
-from dataclasses import dataclass
-from datetime import datetime, timedelta, UTC
-from pathlib import Path
-from typing import Any, Dict, List, Tuple
+import random
 
-import pandas as pd
+import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+from src.optimization import evolutionary
 
-# ======================
-# Config via environment
-# ======================
-STRATEGY = os.getenv("WF_STRATEGY", "src.models.atr_breakout")
-TICKERS = [t.strip() for t in os.getenv("WF_TICKERS", "AAPL,MSFT").split(",") if t.strip()]
-YEARS_BACK = int(os.getenv("WF_YEARS_BACK", "3"))
-DAYS_BACK = int(os.getenv("WF_DAYS_BACK", str(365 * YEARS_BACK)))
-EQUITY = float(os.getenv("WF_EQUITY", "10000"))
 
-N_SPLITS = int(os.getenv("WF_N_SPLITS", "3"))
-TRAIN_DAYS = int(os.getenv("WF_TRAIN_DAYS", "252"))
-TEST_DAYS = int(os.getenv("WF_TEST_DAYS", "63"))
-STEP_DAYS = os.getenv("WF_STEP_DAYS")
-STEP_DAYS = None if STEP_DAYS in (None, "", "None", "none") else int(STEP_DAYS)
+def test_random_param_and_mutate_respect_bounds() -> None:
+    space = {"x": (1, 3), "y": (0.5, 1.5)}
+    random.seed(123)
+    params = evolutionary.random_param(space)
+    assert 1 <= params["x"] <= 3
+    assert 0.5 <= params["y"] <= 1.5
 
-# EA toggles
-USE_EA = bool(int(os.getenv("WF_USE_EA", "0")))   # default OFF for speed
-EA_GEN = int(os.getenv("WF_EA_GEN", "4"))
-EA_POP = int(os.getenv("WF_EA_POP", "12"))
-EA_MIN_TRADES = int(os.getenv("WF_EA_MIN_TRADES", "3"))
-EA_NJOBS = int(os.getenv("WF_EA_NJOBS", "1"))
-SEED = os.getenv("WF_SEED")
-SEED = None if SEED in (None, "", "None", "none") else int(SEED)
+    random.seed(123)
+    mutated = evolutionary.mutate(params, space, rate=1.0)
+    # With rate=1.0 every key is resampled within bounds
+    assert 1 <= mutated["x"] <= 3
+    assert 0.5 <= mutated["y"] <= 1.5
 
-# Default param space (only used if USE_EA=1)
-EA_SPACE: Dict[str, Tuple] = {
-    "breakout_n": (10, 30),
-    "exit_n": (5, 15),
-    "atr_n": (10, 30),
-    "atr_multiple": (1.0, 3.0),
-    "tp_multiple": (0.2, 1.0),
-    "holding_period_limit": (2, 10),
-}
-# Default fixed params (used when USE_EA=0)
-FIXED_PARAMS: Dict[str, Any] = {
-    "breakout_n": 14,
-    "exit_n": 6,
-    "atr_n": 14,
-    "atr_multiple": 2.0,
-    "tp_multiple": 0.5,
-    "holding_period_limit": 5,
-}
 
-# =============
-# Test harness
-# =============
-def banner(title: str):
-    print("\n" + "=" * 72)
-    print(title)
-    print("=" * 72)
+def test_holding_penalty_zero_inside_band() -> None:
+    assert evolutionary._holding_penalty(5.0, 3.0, 10.0) == 0.0
+    assert evolutionary._holding_penalty(2.5, 3.0, 10.0) == pytest.approx(0.5)
+    assert evolutionary._holding_penalty(12.0, 3.0, 10.0) == pytest.approx(2.0)
 
-def leg(title: str, fn, *args, **kwargs):
-    print("\n" + "-" * 72)
-    print(title)
-    print("-" * 72)
-    try:
-        out = fn(*args, **kwargs)
-        print("RESULT: PASS")
-        return True, out
-    except Exception as e:
-        print("RESULT: FAIL")
-        print("ERROR :", repr(e))
-        return False, e
 
-def leg_env():
-    banner("Environment")
-    print("Python:", sys.version.split()[0], f"({sys.executable})")
-    print("PWD   :", os.getcwd())
-    print("ROOT  :", ROOT)
-    print("Strategy :", STRATEGY)
-    print("Tickers  :", TICKERS)
-    print("DaysBack :", DAYS_BACK)
-    print("Equity   :", EQUITY)
-    print("WF splits:", N_SPLITS, "train_days:", TRAIN_DAYS, "test_days:", TEST_DAYS, "step_days:", STEP_DAYS or "<test_days>")
-    print("EA use   :", USE_EA, "gen:", EA_GEN, "pop:", EA_POP, "min_trades:", EA_MIN_TRADES, "n_jobs:", EA_NJOBS, "seed:", SEED)
+def test_rate_penalty_behaviour() -> None:
+    assert evolutionary._rate_penalty(7.0, 5.0, 10.0) == 0.0
+    assert evolutionary._rate_penalty(3.0, 5.0, 10.0) == pytest.approx(2.0)
+    assert evolutionary._rate_penalty(12.0, 5.0, 10.0) == pytest.approx(2.0)
 
-# ============================
-# Local walk-forward utilities
-# ============================
-def _import_strategy_and_utils():
-    L = importlib.import_module("src.data.loader")
-    M = importlib.import_module("src.backtest.metrics")
-    S = importlib.import_module(STRATEGY)
-    E = importlib.import_module("src.optimization.evolutionary")
-    run_strategy = getattr(S, "run_strategy")
-    get_ohlcv = getattr(L, "get_ohlcv")
-    compute_metrics = getattr(M, "compute_core_metrics")
-    evo = getattr(E, "evolutionary_search")
-    return get_ohlcv, run_strategy, compute_metrics, evo, L, S, M, E
 
-@dataclass
-class Split:
-    i: int
-    train_start: datetime
-    train_end: datetime
-    test_start: datetime
-    test_end: datetime
-
-def _make_splits(end: datetime) -> List[Split]:
-    # rolling splits ending at `end`, stepping by step_days or test_days
-    step = STEP_DAYS or TEST_DAYS
-    splits: List[Split] = []
-    cursor_end = end
-    for i in range(N_SPLITS - 1, -1, -1):
-        test_end = cursor_end
-        test_start = test_end - timedelta(days=TEST_DAYS)
-        train_end = test_start
-        train_start = train_end - timedelta(days=TRAIN_DAYS)
-        splits.append(Split(i=i, train_start=train_start, train_end=train_end, test_start=test_start, test_end=test_end))
-        cursor_end = test_end - timedelta(days=step)
-    # chronological order
-    splits.sort(key=lambda s: s.i)
-    return splits
-
-def _load_panel(get_ohlcv, tickers: List[str], start: datetime, end: datetime) -> Dict[str, pd.DataFrame]:
-    data = {}
-    for sym in tickers:
-        df = get_ohlcv(sym, start, end)
-        if df is None or df.empty:
-            raise RuntimeError(f"No data for {sym} {start}→{end}")
-        need = {"open","high","low","close"}
-        if not need.issubset({c.lower() for c in df.columns}):
-            raise RuntimeError(f"{sym}: missing OHLC columns")
-        data[sym] = df
-    return data
-
-def _eval_params_on_period(run_strategy, compute_metrics, params: Dict[str, Any], tickers: List[str],
-                           start: datetime, end: datetime) -> Dict[str, Any]:
-    # equal-weight portfolio: average normalized equity across symbols
-    curves = {}
-    trades_agg: List[dict] = []
-
-    for sym in tickers:
-        res = run_strategy(sym, start, end, EQUITY, params)
-
-        eq = res.get("equity")
-        if eq is None or len(eq) == 0:
-            # skip symbols with no curve
-            continue
-
-        # daily_returns: avoid boolean context on Series
-        daily = res.get("daily_returns")
-        if not isinstance(daily, pd.Series) or daily.empty:
-            daily = eq.pct_change().fillna(0.0)
-
-        # trades: normalize to a list of dicts
-        tr = res.get("trades")
-        if tr is None:
-            tr = []
-        elif isinstance(tr, pd.DataFrame):
-            tr = tr.to_dict("records")
-        elif not isinstance(tr, list):
-            # fallback: wrap single trade-like object
-            tr = [tr]
-
-        trades_agg.extend(tr)
-
-        # normalize equity to start=1 and collect
-        first = float(eq.iloc[0])
-        if first != 0:
-            curves[sym] = (eq / first).astype(float)
-
-    if not curves:
-        return {"metrics": {"trades": 0}}
-
-    port = pd.DataFrame(curves).mean(axis=1, skipna=True)
-    port_daily = port.pct_change().fillna(0.0)
-
-    m = compute_metrics(port, port_daily, trades_agg)
-    return {"metrics": m}
-
-def _ea_or_fixed(evo, use_ea: bool, param_space: Dict[str, Tuple], fixed: Dict[str, Any],
-                 tickers: List[str], start: datetime, end: datetime) -> Dict[str, Any]:
-    if not use_ea:
-        return dict(fixed)
-    top = evo(
-        STRATEGY, tickers, start, end, EQUITY, param_space,
-        generations=EA_GEN, pop_size=EA_POP, min_trades=EA_MIN_TRADES,
-        n_jobs=EA_NJOBS, seed=SEED, progress_cb=lambda *_a, **_k: None, log_file="wf_ea.log"
-    )
-    if not top:
-        return dict(fixed)
-    return dict(top[0][0])  # best params
-
-def walkforward_once(get_ohlcv, run_strategy, compute_metrics, evo):
-    end = datetime.now(UTC)
-    start_global = end - timedelta(days=DAYS_BACK)
-    splits = _make_splits(end)
-
-    results = {
-        "strategy": STRATEGY,
-        "period": {"start": str(start_global), "end": str(end)},
-        "config": {
-            "splits": N_SPLITS, "train_days": TRAIN_DAYS, "test_days": TEST_DAYS, "step_days": STEP_DAYS,
-            "use_ea": USE_EA, "ea_gen": EA_GEN, "ea_pop": EA_POP, "ea_min_trades": EA_MIN_TRADES, "ea_n_jobs": EA_NJOBS,
-        },
-        "splits": [],
-        "aggregate": {}
+def make_metrics(**overrides):
+    base = {
+        "trades": 10,
+        "avg_holding_days": 5.0,
+        "cagr": 0.20,
+        "calmar": 1.5,
+        "sharpe": 1.0,
+        "max_drawdown": -0.25,
     }
-
-    oos_rows = []
-    for s in splits:
-        # Load data once per split (data loader itself caches via your module-level cache)
-        _ = _load_panel(get_ohlcv, TICKERS, s.train_start, s.test_end)
-
-        # Choose params on TRAIN
-        best_params = _ea_or_fixed(evo, USE_EA, EA_SPACE, FIXED_PARAMS, TICKERS, s.train_start, s.train_end)
-
-        # Evaluate OOS on TEST
-        oos = _eval_params_on_period(run_strategy, compute_metrics, best_params, TICKERS, s.test_start, s.test_end)
-        met = oos["metrics"] or {}
-
-        results["splits"].append({
-            "split_idx": s.i,
-            "train_start": str(s.train_start), "train_end": str(s.train_end),
-            "test_start": str(s.test_start), "test_end": str(s.test_end),
-            "best_params": best_params,
-            "train_score": None,  # quick smoke: omitted for speed
-            "oos_metrics": met,
-            "per_symbol": {},     # quick smoke: omitted for speed
-        })
-        if met:
-            oos_rows.append(met)
-
-    # Aggregate simple mean/median over numeric keys we care about
-    if oos_rows:
-        df = pd.DataFrame(oos_rows)
-        results["aggregate"]["oos_mean"] = {k: float(df[k].mean()) for k in df.columns if pd.api.types.is_numeric_dtype(df[k])}
-        results["aggregate"]["oos_median"] = {k: float(df[k].median()) for k in df.columns if pd.api.types.is_numeric_dtype(df[k])}
-    else:
-        results["aggregate"]["oos_mean"] = {}
-        results["aggregate"]["oos_median"] = {}
-
-    return results
-
-# ======================
-# Test legs
-# ======================
-def leg_imports():
-    banner("Import modules")
-    get_ohlcv, run_strategy, compute_metrics, evo, L, S, M, E = _import_strategy_and_utils()
-    print("\n" + "=" * 72)
-    print("Module paths")
-    print("=" * 72)
-    print("loader file   :", getattr(L, "__file__", "<??>"))
-    print("strategy file :", getattr(S, "__file__", "<??>"))
-    print("metrics file  :", getattr(M, "__file__", "<??>"))
-    print("evolutionary  :", getattr(E, "__file__", "<??>"))
-    return get_ohlcv, run_strategy, compute_metrics, evo
-
-def leg_walkforward(get_ohlcv, run_strategy, compute_metrics, evo):
-    banner("Walk-Forward run (local implementation)")
-    res = walkforward_once(get_ohlcv, run_strategy, compute_metrics, evo)
-
-    # quick structural checks
-    if not isinstance(res.get("splits"), list) or len(res["splits"]) == 0:
-        raise AssertionError("walkforward returned empty splits")
-    for i, sr in enumerate(res["splits"]):
-        for k in ("split_idx","train_start","train_end","test_start","test_end","best_params","oos_metrics"):
-            if k not in sr:
-                raise AssertionError(f"split[{i}] missing key '{k}'")
-        if "trades" not in (sr["oos_metrics"] or {}):
-            # metrics always include 'trades' in your compute_core_metrics
-            raise AssertionError(f"split[{i}].oos_metrics missing 'trades'")
-
-    mean = res["aggregate"].get("oos_mean", {})
-    print("\nSummary (OOS mean):")
-    for k in ("total_return","cagr","calmar","sharpe","max_drawdown","trades"):
-        v = mean.get(k)
-        if v is not None:
-            print(f"  {k:>14s}: {v:.4f}")
-
-    s0 = res["splits"][0]
-    print("\nFirst split preview:")
-    print("  dates:", s0["train_start"], "→", s0["train_end"], "| OOS:", s0["test_start"], "→", s0["test_end"])
-    pkeys = ("breakout_n","exit_n","atr_n","atr_multiple","tp_multiple","holding_period_limit")
-    print("  params:", {k: s0["best_params"].get(k) for k in pkeys})
-    print("  oos trades:", s0["oos_metrics"].get("trades"))
-    return res
-
-def main() -> int:
-    leg_env()
-    ok, mods = leg("Import modules", leg_imports)
-    if not ok:
-        return 1
-    get_ohlcv, run_strategy, compute_metrics, evo = mods
-
-    ok, _ = leg("Walk-Forward run", leg_walkforward, get_ohlcv, run_strategy, compute_metrics, evo)
-    if not ok:
-        return 1
+    base.update(overrides)
+    return base
 
 
+def compute_fitness(**metrics_overrides) -> float:
+    metrics = make_metrics(**metrics_overrides)
+    return evolutionary._clamped_fitness(
+        metrics,
+        min_trades=5,
+        min_avg_holding_days_gate=2.0,
+        require_hold_days=False,
+        eps_mdd=1e-3,
+        eps_sharpe=1e-3,
+        alpha_cagr=1.0,
+        beta_calmar=1.0,
+        gamma_sharpe=0.5,
+        min_holding_days=3.0,
+        max_holding_days=10.0,
+        holding_penalty_weight=0.2,
+        trade_rate_min=5.0,
+        trade_rate_max=15.0,
+        trade_rate_penalty_weight=0.1,
+        num_symbols=2,
+        years=1.0,
+    )
 
-    banner("Walk-Forward test completed.")
-    return 0
 
-if __name__ == "__main__":
-    raise SystemExit(main())
+def test_clamped_fitness_applies_gates() -> None:
+    assert compute_fitness(trades=0) == 0.0
+    assert compute_fitness(avg_holding_days=1.0) == 0.0
+    # Non-zero metrics should yield positive score
+    score = compute_fitness()
+    assert score > 0.0
+
+
+def test_clamped_fitness_penalises_outside_preferences() -> None:
+    inside = compute_fitness(avg_holding_days=5.0)
+    low_hold = compute_fitness(avg_holding_days=3.5)
+    high_rate = compute_fitness(trades=40)  # high trade rate for num_symbols=2, years=1 -> rate=20
+    assert low_hold <= inside
+    assert high_rate <= inside


### PR DESCRIPTION
## Summary
- add the missing `os` import to the OHLCV loader so environment flags are respected
- replace interactive smoke scripts in `tests/` with focused unit tests for the loader, training logger, general trainer, and evolutionary helpers
- add a `tests/conftest.py` shim so the package is importable in pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb6b212afc832a947017c51955abe5