### PR TITLE
Handle complex CAGR values when equity turns negative

### DIFF
--- a/src/backtest/metrics.py
+++ b/src/backtest/metrics.py
@@ -62,7 +62,18 @@ def cagr(equity: pd.Series) -> float:
     if days <= 0:
         return 0.0
     years = days / 365.25
-    return float((end_val / start_val) ** (1 / years) - 1.0)
+    if years <= 0:
+        return 0.0
+    ratio = end_val / start_val
+    if ratio <= 0:
+        return 0.0
+    try:
+        value = ratio ** (1 / years) - 1.0
+    except (OverflowError, ValueError):
+        return 0.0
+    if isinstance(value, complex):
+        return 0.0
+    return float(value)
 
 def max_drawdown(equity: pd.Series) -> float:
     if equity is None or len(equity) == 0:


### PR DESCRIPTION
## Summary
- guard the CAGR calculation against non-positive equity ratios and invalid spans
- ensure the function now returns 0 instead of raising when the exponentiation would produce a complex value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3d7a281a4832aa2f9543dfe8f987f