### PR TITLE
Add volatility scaling and trend filters to ATR backtest

### DIFF
--- a/docs/holdout_drawdown_analysis.md
+++ b/docs/holdout_drawdown_analysis.md
@@ -1,0 +1,35 @@
+# July 2024 Holdout Drawdown Analysis
+
+## Summary
+Model Builder trainings that target the `NASDAQ_10` portfolio repeatedly show a sharp equity dip during July 2024. This is not a simulator bug—the holdout window used across the recent EA runs always spans mid-2024, when most of the portfolio constituents sold off 10–25%. The same market regime therefore reappears in every training session, producing the consistent drawdown that appears on the holdout chart.
+
+## Holdout configuration
+Every EA session recorded under `storage/logs/ea/` during the recent work captured a holdout that begins either on 29 March 2024 or 26 April 2024 and runs into late 2025. Regardless of the exact start, the July 2024 sell-off is always part of the evaluation period, so any long-biased breakout configuration is forced to trade through that regime.【3b7f96†L1-L20】
+
+## Price action during July 2024
+The ten symbols inside `NASDAQ_10` all suffered notable declines between 15 July and 9 August 2024. Five of the high-beta names (AMD, ABNB, GOOGL, GOOG, AMZN) fell 12–25%, while even stalwarts like AAPL shed almost 8%. AEP was the lone gainer, so the equal-weighted basket still lost roughly 10.4% over the window.【7f8236†L1-L11】 Sample OHLC data from the Alpaca cache shows the same slump, e.g. AMD sliding from $174 on 8 July to the $138 area by 30 July.【4a67d8†L9-L18】【4a67d8†L21-L30】
+
+### Why the SPY benchmark looks calmer
+The SPY holdout benchmark does not exhibit the same cliff because its sector mix spreads the July shock across 500 names instead of concentrating in mega-cap tech. The cached Alpaca data shows the equal-weighted `NASDAQ_10` basket dropping about 9.3% peak-to-trough between 1 July and 7 August 2024, whereas SPY fell only ~5.1% before stabilizing. By mid-August the SPY drawdown had nearly retraced, but the tech-heavy portfolio remained down ~5.6% as the weakest members (ABNB, AMD, AMZN, the GOOG* twins) were still 13–25% below their July highs while the defensive utility AEP barely budged.【1f786b†L1-L11】 In other words, the recurring loss is a concentration problem: the EA keeps relearning how to trade a basket whose holdout period coincides with a tech-specific correction that the broader S&P 500 avoided.
+
+## What the EA logs show
+Because that sell-off dominates the holdout window, many individuals evaluated by the EA show negative test returns and large drawdowns even when their in-sample performance looked acceptable. For example, several generation-0 candidates report `test_metrics['total_return']` between -4% and -7% and `max_drawdown` worse than -17% to -23%.【d962d5†L6-L147】 Later generations manage the damage better—the final best candidate from 6 Oct 2025 still records a maximum drawdown of about -6.9% while finishing the holdout up 17.7%, but that dip is a direct imprint of the July regime.【9c3b9a†L1-L2】
+
+## Implications
+Until the training data window or the portfolio composition changes, every EA search will continue to experience that July 2024 shock. Possible mitigations include:
+
+- Incorporating symbols or hedges that diversify the heavy mega-cap tech exposure.
+- Allowing the EA to short or hold cash so it can sidestep the sell-off.
+- Shifting the holdout window (or adding multiple rolling windows) to confirm the behaviour is localized to that event.
+
+Understanding that the drawdown is data-driven rather than a simulation failure should make it easier to reason about strategy tweaks.
+
+### How parameter sets could adapt
+Because the EA currently optimizes long-only, breakout-oriented behaviours, most parameter sets are forced to stay fully invested as prices roll over. To blunt the July drawdown without altering the data, the model would need knobs that reward de-risking once the sell-off starts. Examples include:
+
+- **Volatility-sensitive position sizing.** If the engine allowed ATR- or variance-based scaling, a parameter set that targets constant volatility (e.g., reduce gross exposure when 14-day ATR spikes) would naturally cut risk as July’s range expansion appears.
+- **Trend or regime filters.** Adding moving-average alignment, slope constraints, or breadth filters as tunable parameters would let the EA exit—or never enter—longs when the basket flips into a short-term downtrend.
+- **Stop or time-based exits.** Permitting hard stops, trailing stops, or “maximum bar hold” rules would hand the search space a direct way to truncate losers instead of riding them through the trough.
+- **Cash or hedge allocation.** If the strategy template exposed cash targets or inverse/market-neutral hedges (e.g., short QQQ, long VIX calls) as parameters, the EA could discover defensive combinations for that regime.
+
+In short, no single parameter tweak guarantees a win, but expanding the parameter space to include volatility targeting, trend filters, explicit exits, or hedging levers would give the EA the theoretical ability to surface parameter sets that sidestep most of the July 2024 damage.

--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -122,6 +122,9 @@ def _env_float(name: str, default: float = 0.0) -> float:
 
 # ---------- Logging ----------
 
+from src.utils.logging_setup import SafeRotatingFileHandler
+
+
 logger = logging.getLogger("backtest.engine")
 _ENGINE_LOGGER_CONFIGURED = False
 
@@ -143,7 +146,7 @@ def _ensure_engine_logger() -> None:
             root_logger = logging.getLogger()
             has_rotating = any(isinstance(h, RotatingFileHandler) for h in root_logger.handlers)
         if not has_rotating:
-            handler = RotatingFileHandler(
+            handler = SafeRotatingFileHandler(
                 os.path.join(log_dir, "engine.log"), maxBytes=5 * 1024 * 1024, backupCount=3
             )
             handler.setLevel(log_level)

--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -391,6 +391,15 @@ class ATRParams:
     prob_gate_enabled: bool = False   # probability gate toggle (calibrated LR)
     prob_gate_threshold: float = 0.0  # minimum probability to allow entry
     prob_model_id: str = ""           # identifier for stored calibrated model
+    vol_target_enabled: bool = False  # enable ATR-based volatility targeting for position sizing
+    vol_target_target_pct: float = 0.02  # desired ATR % of price to target (e.g., 2% daily move)
+    vol_target_atr_window: int = 14   # ATR window to use for volatility targeting (0 -> use atr_n)
+    vol_target_min_leverage: float = 0.0  # floor on capital allocation multiple when targeting vol
+    vol_target_max_leverage: float = 1.0  # cap on capital allocation multiple when targeting vol
+    trend_filter_ma: int = 0          # optional MA window; price must be above MA to allow longs
+    trend_filter_slope_lookback: int = 0  # lookback for MA slope constraint (bars)
+    trend_filter_slope_threshold: float = 0.0  # minimum slope per bar (in pct terms) to stay long
+    trend_filter_exit: bool = False   # if True, exit positions when filter fails
 
 # Defaults for optional dip overlay when strategies request it via extra_params.
 DIP_OVERLAY_DEFAULTS: Dict[str, Any] = {
@@ -655,6 +664,66 @@ def backtest_atr_breakout(
     elif prob_gate_enabled:
         prob_gate_enabled = False
     atr = wilder_atr(df["high"], df["low"], df["close"], n=params.atr_n)
+    vol_target_enabled = bool(getattr(params, "vol_target_enabled", False))
+    vol_target_target_pct = max(0.0, _coerce_float(getattr(params, "vol_target_target_pct", 0.0), 0.0))
+    vol_target_min_leverage = max(
+        0.0, _coerce_float(getattr(params, "vol_target_min_leverage", 0.0), 0.0)
+    )
+    vol_target_max_leverage = max(
+        vol_target_min_leverage,
+        _coerce_float(getattr(params, "vol_target_max_leverage", 1.0), 1.0),
+    )
+    vol_target_atr_window = int(
+        max(1, _coerce_float(getattr(params, "vol_target_atr_window", params.atr_n), params.atr_n))
+    )
+    vol_target_active = vol_target_enabled and vol_target_target_pct > 0.0
+    if vol_target_active:
+        if vol_target_atr_window != params.atr_n:
+            vol_target_atr = wilder_atr(
+                df["high"], df["low"], df["close"], n=vol_target_atr_window
+            )
+        else:
+            vol_target_atr = atr.copy()
+        atr_pct = (vol_target_atr / df["close"]).replace([np.inf, -np.inf], np.nan)
+        ratio = vol_target_target_pct / atr_pct
+        ratio = ratio.replace([np.inf, -np.inf], np.nan)
+        ratio = ratio.clip(lower=vol_target_min_leverage, upper=vol_target_max_leverage)
+        default_scale = vol_target_max_leverage if vol_target_max_leverage > 0 else 0.0
+        vol_target_scale_series = ratio.fillna(default_scale)
+        vol_target_scale_series = vol_target_scale_series.reindex(df.index).fillna(default_scale)
+        vol_target_scale_series = vol_target_scale_series.astype(float)
+        vol_target_atr_pct = atr_pct.reindex(df.index).fillna(0.0).astype(float)
+    else:
+        vol_target_scale_series = pd.Series(1.0, index=df.index, dtype=float)
+        vol_target_atr_pct = pd.Series(0.0, index=df.index, dtype=float)
+    trend_filter_ma = int(max(0, _coerce_float(getattr(params, "trend_filter_ma", 0), 0.0)))
+    trend_filter_slope_lookback = int(
+        max(0, _coerce_float(getattr(params, "trend_filter_slope_lookback", 0), 0.0))
+    )
+    trend_filter_slope_threshold = _coerce_float(
+        getattr(params, "trend_filter_slope_threshold", 0.0), 0.0
+    )
+    trend_filter_exit = bool(getattr(params, "trend_filter_exit", False))
+    trend_filter_enabled = (trend_filter_ma > 1) or (trend_filter_slope_lookback > 0)
+    trend_filter_price_ok = pd.Series(True, index=df.index, dtype=bool)
+    trend_filter_slope_ok = pd.Series(True, index=df.index, dtype=bool)
+    trend_filter_ok = pd.Series(True, index=df.index, dtype=bool)
+    slope_basis = df["close"].copy()
+    if trend_filter_ma > 1:
+        trend_ma_series = df["close"].rolling(window=trend_filter_ma, min_periods=trend_filter_ma).mean()
+        trend_filter_price_ok = (df["close"] >= trend_ma_series).fillna(False)
+        slope_basis = trend_ma_series
+    if trend_filter_enabled and trend_filter_slope_lookback > 0:
+        shifted = slope_basis.shift(trend_filter_slope_lookback)
+        slope_pct = (slope_basis / shifted) - 1.0
+        if trend_filter_slope_lookback > 0:
+            slope_pct = slope_pct / trend_filter_slope_lookback
+        slope_pct = slope_pct.replace([np.inf, -np.inf], np.nan)
+        trend_filter_slope_ok = (slope_pct >= trend_filter_slope_threshold).fillna(False)
+    if trend_filter_enabled:
+        trend_filter_ok = (trend_filter_price_ok & trend_filter_slope_ok).fillna(False)
+    else:
+        trend_filter_ok = pd.Series(True, index=df.index, dtype=bool)
     roll_high = df["close"].rolling(params.breakout_n).max()
     roll_low = df["close"].rolling(params.exit_n).min()
     prior_high = roll_high.shift(1)
@@ -748,6 +817,7 @@ def backtest_atr_breakout(
     entry_breakdown: Dict[str, float] = {"total_cost": 0.0, "slippage_cost": 0.0, "commission_cost": 0.0, "fee_cost": 0.0,
                                          "slippage_bps": 0.0, "commission_bps": 0.0, "fill_price": 0.0}
     entry_notional = 0.0
+    entry_volatility_scale = 1.0
 
     cash_gross = float(starting_equity)
     cash_net = float(starting_equity)
@@ -778,6 +848,8 @@ def backtest_atr_breakout(
         "blocked_by_prob_gate": 0,
         "blocked_by_min_hold": 0,
         "blocked_by_cooldown": 0,
+        "blocked_by_trend_filter": 0,
+        "blocked_by_volatility": 0,
     }
     entry_count = 0
     exit_count = 0
@@ -786,6 +858,8 @@ def backtest_atr_breakout(
     blocked_by_prob_gate = 0
     blocked_by_min_hold = 0
     blocked_by_cooldown = 0
+    blocked_by_trend_filter = 0
+    blocked_by_volatility = 0
 
     log_per_trade = logger.isEnabledFor(logging.DEBUG) and _env_flag("LOG_TRADES", False)
     try:
@@ -876,7 +950,13 @@ def backtest_atr_breakout(
         if in_pos and exit_trigger is None:
             exit_reason = None
             exit_px = None
-            if price_close < roll_low.iloc[i]:
+            if trend_filter_enabled and trend_filter_exit:
+                trend_pass_today = True
+                if i < len(trend_filter_ok):
+                    trend_pass_today = bool(trend_filter_ok.iloc[i])
+                if not trend_pass_today:
+                    exit_reason = "trend_filter"
+            if exit_reason is None and price_close < roll_low.iloc[i]:
                 exit_reason = "roll_low"
             if exit_reason is None and params.tp_multiple > 0 and entry_idx is not None:
                 atr_at_entry = atr.iloc[entry_idx]
@@ -949,6 +1029,22 @@ def backtest_atr_breakout(
                 entry_allowed = False
                 blocked_by_prob_gate += 1
                 state_tracking["blocked_by_prob_gate"] = blocked_by_prob_gate
+            if entry_allowed and trend_filter_enabled:
+                trend_pass = True
+                if i < len(trend_filter_ok):
+                    trend_pass = bool(trend_filter_ok.iloc[i])
+                if not trend_pass:
+                    entry_allowed = False
+                    blocked_by_trend_filter += 1
+                    state_tracking["blocked_by_trend_filter"] = blocked_by_trend_filter
+            if entry_allowed and vol_target_active:
+                vol_scale_today = 0.0
+                if i < len(vol_target_scale_series):
+                    vol_scale_today = float(vol_target_scale_series.iloc[i])
+                if vol_scale_today <= 0.0:
+                    entry_allowed = False
+                    blocked_by_volatility += 1
+                    state_tracking["blocked_by_volatility"] = blocked_by_volatility
             if entry_allowed:
                 trigger = {
                     "signal_idx": i,
@@ -1039,6 +1135,19 @@ def backtest_atr_breakout(
                     + abs(exit_breakdown.get("commission_bps", 0.0)) * abs(notional_exit)
                 ) / combined_notional
 
+            entry_atr_pct = 0.0
+            if vol_target_active and entry_idx is not None and entry_idx < len(vol_target_atr_pct):
+                try:
+                    entry_atr_pct = float(vol_target_atr_pct.iloc[entry_idx])
+                except Exception:
+                    entry_atr_pct = 0.0
+            trend_filter_entry_pass = True
+            if trend_filter_enabled and entry_idx is not None and entry_idx < len(trend_filter_ok):
+                try:
+                    trend_filter_entry_pass = bool(trend_filter_ok.iloc[entry_idx])
+                except Exception:
+                    trend_filter_entry_pass = True
+
             trade_record = {
                 "entry_time": entry_time,
                 "exit_time": ts,
@@ -1093,6 +1202,10 @@ def backtest_atr_breakout(
                 "price_after": entry_price_after,
                 "slip_bps": float(slip_bps_weighted),
                 "fees_bps": float(fee_bps_weighted),
+                "volatility_scale": float(entry_volatility_scale),
+                "entry_atr_pct": float(entry_atr_pct),
+                "trend_filter_active": bool(trend_filter_enabled),
+                "trend_filter_pass": bool(trend_filter_entry_pass),
                 "prob_gate_probability": float(entry_gate_probability)
                 if entry_gate_probability is not None
                 else None,
@@ -1124,6 +1237,8 @@ def backtest_atr_breakout(
                         "persistence": blocked_by_persistence,
                         "min_hold": blocked_by_min_hold,
                         "cooldown": blocked_by_cooldown,
+                        "trend": blocked_by_trend_filter,
+                        "volatility": blocked_by_volatility,
                     },
                 )
 
@@ -1140,6 +1255,7 @@ def backtest_atr_breakout(
                 dip_cooldown_until_idx = max(dip_cooldown_until_idx, i + dip_cooldown_days)
             entry_breakdown = {"total_cost": 0.0, "slippage_cost": 0.0, "commission_cost": 0.0, "fee_cost": 0.0,
                                "slippage_bps": 0.0, "commission_bps": 0.0, "fill_price": 0.0}
+            entry_volatility_scale = 1.0
 
         if entry_trigger is not None and not in_pos:
             base_price = entry_trigger.get("override_price")
@@ -1149,15 +1265,28 @@ def backtest_atr_breakout(
                 else:
                     base_price = price_close if exec_fill_where == "close" else price_open
             entry_price = _safe_price(base_price, price_close)
-            if entry_price > 0 and cash_gross > 0:
-                qty = cash_gross / entry_price
-                position_qty = float(qty)
-                entry_idx = i
-                entry_time = ts
-                entry_decision_price = float(entry_price)
-                entry_notional = entry_decision_price * position_qty
-                cash_gross -= entry_notional
-                cash_net -= entry_notional
+            executed_entry = False
+            entry_volatility_candidate = 1.0
+            if entry_price > 0 and cash_gross != 0:
+                target_notional = cash_gross
+                if vol_target_active and i < len(vol_target_scale_series):
+                    entry_volatility_candidate = float(vol_target_scale_series.iloc[i])
+                    if entry_volatility_candidate < 0.0:
+                        entry_volatility_candidate = 0.0
+                    target_notional = cash_gross * entry_volatility_candidate
+                if target_notional > 0.0:
+                    qty = target_notional / entry_price
+                    if qty > 0:
+                        position_qty = float(qty)
+                        entry_idx = i
+                        entry_time = ts
+                        entry_decision_price = float(entry_price)
+                        entry_notional = entry_decision_price * position_qty
+                        cash_gross -= entry_notional
+                        cash_net -= entry_notional
+                        entry_volatility_scale = entry_volatility_candidate
+                        executed_entry = True
+            if executed_entry:
                 entry_breakdown = cost_model.compute_fill("long", "entry", entry_decision_price, position_qty)
                 if phase0_cost_model.enabled:
                     entry_fill_price, entry_slip_bps, entry_fee_bps = _apply_costs(
@@ -1218,6 +1347,8 @@ def backtest_atr_breakout(
                             "persistence": blocked_by_persistence,
                             "min_hold": blocked_by_min_hold,
                             "cooldown": blocked_by_cooldown,
+                            "trend": blocked_by_trend_filter,
+                            "volatility": blocked_by_volatility,
                         },
                     )
 
@@ -1247,6 +1378,8 @@ def backtest_atr_breakout(
         "notional_exit",
         "entry_per_trade_fee_bps",
         "exit_per_trade_fee_bps",
+        "volatility_scale",
+        "entry_atr_pct",
     ]
     for col in required_float_cols:
         if col not in trades_df.columns:


### PR DESCRIPTION
## Summary
- extend `ATRParams` with volatility targeting and trend filter knobs for the breakout engine
- compute ATR-based position scaling and trend regime checks to gate entries and trigger exits, logging their effects in trade records
- surface the new telemetry in trade logs so downstream analysis can see volatility scales and filter status

## Testing
- pytest tests/test_prob_gate_backtest.py

------
https://chatgpt.com/codex/tasks/task_e_68e6770f5794832a8d639aa6eb4ada98