### PR TITLE
Add optional portfolio price overlay to TRI comparison

### DIFF
--- a/pages/3_Model_Inspector.py
+++ b/pages/3_Model_Inspector.py
@@ -1315,6 +1315,7 @@ def main():
         tri_curve,
         test_start=test_start,
         test_end=test_end,
+        portfolio_tickers=tickers,
     )
 
     # Debug trace from the equity provider


### PR DESCRIPTION
## Summary
- add support for overlaying normalized portfolio ticker prices on the TRI comparison chart via a single toggle
- cache and normalize OHLCV closes so underlying tickers share the chart scale and provide legend-driven visibility control
- pass the inspected portfolio's tickers into the TRI panel so users can enable the new overlay from the Model Inspector page

## Testing
- `pytest` *(fails: pre-existing data pipeline/index catalog fixtures missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6a7a5d2a4832aa14ad33a4ba49458