### PR TITLE
Annotate TRI legend with best individual

### DIFF
--- a/pages/3_Model_Inspector.py
+++ b/pages/3_Model_Inspector.py
@@ -1018,8 +1018,29 @@ def _plot_leaders_through_gen(
         end_equity = ec_train["equity"].iloc[-1] if not ec_train.empty else starting_equity
         ec_test = run_equity_curve(strategy, tickers, test_start, test_end, end_equity, params)
         ec = pd.concat([ec_train, ec_test], ignore_index=True)
-        name = f"Gen {g} (ret {row['total_return']:.3f})"
-        fig.add_trace(go.Scatter(x=ec["date"], y=ec["equity"], mode="lines", name=name, line=dict(width=1)))
+        legend_label = _best_individual_label(row)
+        if not legend_label:
+            base = f"Gen {g}"
+            idx_label = _coerce_individual_id(row.get("idx")) if "idx" in row else None
+            if idx_label:
+                base = f"{base} - idx{idx_label}"
+            try:
+                ret_value = float(row.get("total_return"))
+            except Exception:
+                ret_value = math.nan
+            if math.isfinite(ret_value):
+                legend_label = f"{base} (ret {ret_value:.3f})"
+            else:
+                legend_label = base
+        fig.add_trace(
+            go.Scatter(
+                x=ec["date"],
+                y=ec["equity"],
+                mode="lines",
+                name=legend_label,
+                line=dict(width=1),
+            )
+        )
 
     # all-flat annotation
     if len(fig.data) > 0:

--- a/src/utils/tri_panel.py
+++ b/src/utils/tri_panel.py
@@ -294,6 +294,7 @@ def render_tri_panel(
     test_start: "pd.Timestamp | str | None" = None,
     test_end: "pd.Timestamp | str | None" = None,
     show_test_toggle: bool = True,
+    strategy_label: Optional[str] = None,
 ) -> None:
     st.markdown(f"#### {title}")
     strategy_norm = _normalize_curve(strategy_curve)
@@ -309,8 +310,9 @@ def render_tri_panel(
         logger.warning("tri_panel SPY normalization failed")
         st.warning("SPY TRI data unavailable (loader missing or returned no data).")
         return
+    strategy_name = strategy_label or "Strategy"
     combined = pd.concat(
-        [strategy_norm.rename("Strategy"), spy_norm.rename("SPY (TRI)")],
+        [strategy_norm.rename(strategy_name), spy_norm.rename("SPY (TRI)")],
         axis=1,
         join="inner",
     ).dropna()
@@ -368,7 +370,7 @@ def render_tri_panel(
                 st.info("Test window start values must be positive; displaying full history.")
             else:
                 combined_view = test_view.divide(first_row)
-    strategy_aligned = combined_view["Strategy"]
+    strategy_aligned = combined_view[strategy_name]
     spy_aligned = combined_view["SPY (TRI)"]
     excess_index = strategy_aligned / spy_aligned
     if not excess_index.empty:
@@ -381,8 +383,8 @@ def render_tri_panel(
     metrics = pd.DataFrame(
         {
             "Metric": [
-                "Strategy CAGR",
-                "Strategy MaxDD",
+                f"{strategy_name} CAGR",
+                f"{strategy_name} MaxDD",
                 "SPY (TRI) CAGR",
                 "SPY (TRI) MaxDD",
                 "Tracking Error (annualized)",
@@ -401,7 +403,7 @@ def render_tri_panel(
 
     fig = go.Figure()
     for column, color in (
-        ("Strategy", "#1f77b4"),
+        (strategy_name, "#1f77b4"),
         ("SPY (TRI)", "#ff7f0e"),
         ("Excess Index", "#2ca02c"),
     ):


### PR DESCRIPTION
## Summary
- surface the selected generation winner's identifier in the TRI comparison by forwarding a formatted label from the model inspector
- allow the TRI panel renderer to accept a custom strategy label so the legend and metrics reflect the highlighted individual

## Testing
- `pytest` *(fails: known data fixture and API expectations in stock tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e6a859635c832aa68772e030b98812