### PR TITLE
Add holdout diagnostics charts to model builder

### DIFF
--- a/docs/model_builder_visualization_ideas.md
+++ b/docs/model_builder_visualization_ideas.md
@@ -1,0 +1,41 @@
+# Model Builder Visualization Enhancements
+
+The existing holdout equity curve normalizes per-symbol P\&L streams by the first non-zero observation. When many strategies
+report a zero balance until the first closing trade, this produces a flat "no trades" segment at the start of the chart. To give
+traders a clearer picture of out-of-sample behaviour, consider replacing or augmenting that chart with the following views.
+
+## 1. Starting-Equity Anchored Equity Curve
+- Anchor the equity curve to the configured starting equity (or the first timestamp) rather than the first non-zero trade.
+- Plot both the strategy equity and the benchmark on the same axes to highlight relative performance from day one.
+- Optional: add shading for periods where the strategy is outperforming/underperforming the benchmark.
+
+## 2. Rolling Performance Heatmap
+- Render a 2D heatmap where the x-axis is time and the y-axis is a rolling window length (e.g., 5, 10, 20, 60 trading days).
+- Each cell shows the annualized return or Sharpe ratio for that window, revealing momentum regimes at a glance.
+- Useful for spotting when the strategy repeatedly stalls or accelerates in the holdout.
+
+## 3. Trade Lifecycle Timeline
+- Plot each fill as a horizontal bar spanning entry to exit, positioned vertically by symbol or strategy leg.
+- Encode profit/loss with color and bar thickness with position size.
+- Provides intuition on trade overlap, holding periods, and whether inactivity stems from filters or market conditions.
+
+## 4. Drawdown vs. Exposure Scatter
+- Each point represents a trading day (or hour) with x = net exposure (% of capital deployed) and y = current drawdown.
+- Helps diagnose whether large drawdowns coincide with maxed-out exposure or leverage.
+- Can be extended with marginal histograms to emphasize distribution tails.
+
+## 5. Cumulative Net Exposure Chart
+- Stack area chart showing long, short, and cash allocations through time.
+- When paired with the equity curve, clarifies whether flat performance stems from being flat/cash or from losing trades.
+
+## 6. Trade Frequency & Hit Rate Dashboard
+- Combine two small multiples: (a) rolling trade count per period, (b) rolling win rate / expectancy.
+- Signals whether the strategy is encountering fewer opportunities or simply underperforming on existing trades.
+
+## Layout Suggestions
+- **Two-column layout:** equity curve (anchored) on the left, dashboard of rolling stats on the right.
+- **Tabbed interface:** separate tabs for equity, trade lifecycle, and diagnostics to avoid clutter while keeping related charts a single click away.
+- **Small multiples:** align charts vertically with shared x-axis (time) for quick cross-comparison.
+
+Implementing even one of these replacements will help traders understand whether a flat holdout segment reflects inactivity,
+risk management, or simply delayed trade closures.

--- a/pages/2_Model_Builder.py
+++ b/pages/2_Model_Builder.py
@@ -4,18 +4,27 @@ from __future__ import annotations
 import json
 import os
 import re
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from importlib import import_module
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+import numpy as np
 import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
 import streamlit as st
 
-from src.utils.holdout_chart import init_chart, on_generation_end, set_config  # package path fallback
 from src.utils.training_logger import TrainingLogger
 from src.data.portfolio_prefetch import intersection_range
-from src.storage import append_to_portfolio, list_portfolios, load_portfolio, save_strategy_params
+from src.storage import (
+    append_to_portfolio,
+    get_benchmark_total_return,
+    list_portfolios,
+    load_portfolio,
+    save_strategy_params,
+)
 
 DIP_STRATEGY_MODULE = "src.models.atr_dip_breakout"
 PARAM_PROFILE_PATH = (
@@ -592,6 +601,211 @@ def _write_kv_table(d: Dict[str, Any], title: str = ""):
     st.dataframe(df, width="stretch", height=min(360, 40 + 28 * len(df)))
 
 
+HOLDOUT_EQUITY_KEY = "adapter_holdout_equity_series"
+HOLDOUT_BENCHMARK_KEY = "adapter_holdout_benchmark_series"
+HOLDOUT_RETURNS_KEY = "adapter_holdout_returns_series"
+HOLDOUT_TRADES_KEY = "adapter_holdout_trades"
+
+
+@dataclass
+class PortfolioHoldoutResult:
+    equity: pd.Series = field(default_factory=lambda: pd.Series(dtype=float))
+    ratio: pd.Series = field(default_factory=lambda: pd.Series(dtype=float))
+    per_symbol_equity: Dict[str, pd.Series] = field(default_factory=dict)
+    per_symbol_ratio: Dict[str, pd.Series] = field(default_factory=dict)
+    trades: Dict[str, List[Dict[str, Any]]] = field(default_factory=dict)
+
+
+def _ensure_dt_index(series: pd.Series) -> pd.Series:
+    if not isinstance(series.index, pd.DatetimeIndex):
+        try:
+            series.index = pd.to_datetime(series.index)
+        except Exception:
+            return series
+    if series.index.tz is not None:
+        try:
+            series.index = series.index.tz_convert(None)
+        except Exception:
+            series.index = series.index.tz_localize(None)
+    return series.sort_index()
+
+
+def _flatten_trades(trades: Dict[str, List[Dict[str, Any]]]) -> pd.DataFrame:
+    rows: List[Dict[str, Any]] = []
+    for symbol, trade_list in (trades or {}).items():
+        if not isinstance(trade_list, list):
+            continue
+        for trade in trade_list:
+            if not isinstance(trade, dict):
+                continue
+            entry = trade.get("entry_time") or trade.get("entry_dt")
+            exit_ = trade.get("exit_time") or trade.get("exit_dt")
+            if entry is None or exit_ is None:
+                continue
+            entry_ts = pd.to_datetime(entry, errors="coerce")
+            exit_ts = pd.to_datetime(exit_, errors="coerce")
+            if pd.isna(entry_ts) or pd.isna(exit_ts):
+                continue
+            rows.append(
+                {
+                    "symbol": symbol,
+                    "entry_time": entry_ts.tz_localize(None) if getattr(entry_ts, "tzinfo", None) else entry_ts,
+                    "exit_time": exit_ts.tz_localize(None) if getattr(exit_ts, "tzinfo", None) else exit_ts,
+                    "return_pct": float(trade.get("return_pct", 0.0) or 0.0),
+                    "holding_days": int(trade.get("holding_days", 0) or 0),
+                    "quantity": float(trade.get("quantity", trade.get("qty", 0.0)) or 0.0),
+                    "net_pnl": float(trade.get("net_pnl", 0.0) or 0.0),
+                    "notional_entry": float(trade.get("notional_entry", trade.get("notional", 0.0)) or 0.0),
+                }
+            )
+    if not rows:
+        return pd.DataFrame(columns=["symbol", "entry_time", "exit_time", "return_pct"])
+    df = pd.DataFrame(rows)
+    df = df.sort_values("entry_time")
+    return df
+
+
+def _render_holdout_equity_chart(
+    placeholder: st.delta_generator.DeltaGenerator,
+    equity: pd.Series | None,
+    benchmark: pd.Series | None,
+) -> None:
+    if equity is None or equity.empty:
+        placeholder.info("Holdout equity will appear when a best candidate is available.")
+        return
+
+    equity = _ensure_dt_index(equity.copy())
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=list(equity.index),
+            y=[float(v) for v in equity.values],
+            mode="lines",
+            name="Strategy",
+            line=dict(width=2.2, color="#1f78b4"),
+        )
+    )
+
+    if benchmark is not None and not benchmark.empty:
+        benchmark = _ensure_dt_index(benchmark.copy())
+        bench_aligned = benchmark.reindex(equity.index).ffill().dropna()
+        if not bench_aligned.empty:
+            fig.add_trace(
+                go.Scatter(
+                    x=list(bench_aligned.index),
+                    y=[float(v) for v in bench_aligned.values],
+                    mode="lines",
+                    name="Benchmark",
+                    line=dict(width=1.8, color="#6c757d", dash="dash"),
+                )
+            )
+
+    fig.update_layout(
+        title="Holdout equity (anchored at starting capital)",
+        margin=dict(l=10, r=10, t=40, b=10),
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1.0),
+        xaxis_title="Date",
+        yaxis_title="Equity ($)",
+    )
+    placeholder.plotly_chart(fig, use_container_width=True)
+
+
+def _render_holdout_heatmap(
+    placeholder: st.delta_generator.DeltaGenerator,
+    returns: pd.Series | None,
+) -> None:
+    if returns is None or returns.dropna().empty:
+        placeholder.info("Rolling performance heatmap will populate after a completed holdout run.")
+        return
+
+    returns = _ensure_dt_index(returns.copy())
+    windows = [5, 10, 20, 60]
+    metrics: Dict[str, pd.Series] = {}
+    for window in windows:
+        if len(returns) < window:
+            metrics[f"{window}-day"] = pd.Series(np.nan, index=returns.index)
+            continue
+        roll_prod = (1.0 + returns).rolling(window).apply(lambda arr: float(np.prod(arr)), raw=True)
+        roll_prod = roll_prod.where(roll_prod > 0.0)
+        ann_return = roll_prod.pow(252 / window) - 1.0
+        metrics[f"{window}-day"] = ann_return * 100.0
+
+    heatmap_df = pd.DataFrame(metrics).dropna(how="all")
+    if heatmap_df.empty:
+        placeholder.info("Not enough overlapping holdout data to compute rolling performance windows yet.")
+        return
+
+    heatmap_df = heatmap_df.fillna(np.nan)
+    z = heatmap_df.T.values
+    x = list(heatmap_df.index)
+    y = list(heatmap_df.columns)
+    fig = go.Figure(
+        data=
+        [
+            go.Heatmap(
+                x=x,
+                y=y,
+                z=z,
+                colorscale="RdYlGn",
+                colorbar=dict(title="Ann. return (%)"),
+                zmid=0,
+                hovertemplate="Window=%{y}<br>Date=%{x|%Y-%m-%d}<br>Ann. return=%{z:.2f}%<extra></extra>",
+            )
+        ]
+    )
+    fig.update_layout(
+        title="Rolling performance heatmap",
+        margin=dict(l=10, r=10, t=40, b=30),
+        xaxis_title="Date",
+    )
+    placeholder.plotly_chart(fig, use_container_width=True)
+
+
+def _render_trade_timeline(
+    placeholder: st.delta_generator.DeltaGenerator,
+    trades_df: pd.DataFrame | None,
+    max_trades: int = 200,
+) -> None:
+    if trades_df is None or trades_df.empty:
+        placeholder.info("Trade timeline will display once closed holds appear in the holdout window.")
+        return
+
+    df = trades_df.copy()
+    df = df.dropna(subset=["entry_time", "exit_time"])
+    if df.empty:
+        placeholder.info("Trade timeline will display once closed holds appear in the holdout window.")
+        return
+    df = df.sort_values("entry_time")
+    if len(df) > max_trades:
+        df = df.iloc[-max_trades:]
+
+    df["return_pct_display"] = df["return_pct"] * 100.0
+    df["duration_days"] = (df["exit_time"] - df["entry_time"]).dt.days.clip(lower=0)
+
+    fig = px.timeline(
+        df,
+        x_start="entry_time",
+        x_end="exit_time",
+        y="symbol",
+        color="return_pct_display",
+        color_continuous_scale="RdYlGn",
+        hover_data={
+            "return_pct_display": ":.2f",
+            "duration_days": True,
+            "quantity": ":.2f",
+            "net_pnl": ":.2f",
+        },
+    )
+    fig.update_layout(
+        title="Trade lifecycle timeline",
+        margin=dict(l=10, r=10, t=40, b=30),
+        coloraxis_colorbar=dict(title="Return (%)"),
+    )
+    fig.update_yaxes(autorange="reversed")
+    fig.update_coloraxes(cmid=0)
+    placeholder.plotly_chart(fig, use_container_width=True)
+
+
 def _portfolio_equity_curve(
         strategy_dotted: str,
         tickers: List[str],
@@ -599,22 +813,34 @@ def _portfolio_equity_curve(
         end,
         starting_equity: float,
         params: Dict[str, Any],
-) -> pd.Series:
+) -> PortfolioHoldoutResult:
     """Simulate aggregated portfolio equity for the given params on [start, end)."""
 
     try:
         mod = _safe_import(strategy_dotted)
         run = getattr(mod, "run_strategy")
     except Exception:
-        return pd.Series(dtype=float)
+        return PortfolioHoldoutResult()
 
-    curves: Dict[str, pd.Series] = {}
+    base_equity = float(starting_equity)
+    per_symbol_equity: Dict[str, pd.Series] = {}
+    per_symbol_ratio: Dict[str, pd.Series] = {}
+    trades_by_symbol: Dict[str, List[Dict[str, Any]]] = {}
+
     for sym in tickers:
         try:
             result = run(sym, start, end, starting_equity, params)
         except Exception:
             continue
-        eq = result.get("equity")
+
+        if isinstance(result, dict):
+            trades_payload = result.get("trades")
+            if isinstance(trades_payload, list):
+                trades_by_symbol[sym] = [dict(t) for t in trades_payload if isinstance(t, dict)]
+            eq = result.get("equity")
+        else:
+            eq = None
+
         if eq is None or len(eq) == 0:
             continue
         if isinstance(eq, pd.DataFrame):
@@ -627,6 +853,7 @@ def _portfolio_equity_curve(
                 eq = pd.Series(eq)
             except Exception:
                 continue
+
         eq = eq.dropna()
         if eq.empty:
             continue
@@ -643,33 +870,61 @@ def _portfolio_equity_curve(
             eq = eq.astype(float)
         except Exception:
             continue
-        first_valid = None
-        for val in eq.values:
-            if pd.isna(val):
-                continue
-            try:
-                fv = float(val)
-            except (TypeError, ValueError):
-                continue
-            if abs(fv) > 1e-9:
-                first_valid = fv
-                break
-        if first_valid is None:
+
+        eq = _ensure_dt_index(eq)
+        if eq.empty:
             continue
-        norm = (eq / first_valid).astype(float)
-        curves[sym] = norm
 
-    if not curves:
-        return pd.Series(dtype=float)
+        first_value = float(eq.iloc[0]) if len(eq) else 0.0
+        if abs(first_value) < 1e-9:
+            anchored = eq + base_equity
+        else:
+            anchored = eq
 
-    df = pd.DataFrame(curves).sort_index()
-    df = df.ffill().dropna(how="all")
-    if df.empty:
-        return pd.Series(dtype=float)
+        anchored = anchored.astype(float)
+        anchored = _ensure_dt_index(anchored)
+        if anchored.empty:
+            continue
 
-    portfolio = df.mean(axis=1, skipna=True) * float(starting_equity)
-    portfolio.name = "portfolio_equity"
-    return portfolio
+        start_val = float(anchored.iloc[0]) if len(anchored) else 0.0
+        if abs(start_val) < 1e-9:
+            continue
+
+        ratio = (anchored / start_val).astype(float)
+        per_symbol_equity[sym] = anchored
+        per_symbol_ratio[sym] = ratio
+
+    if not per_symbol_ratio:
+        return PortfolioHoldoutResult(trades=trades_by_symbol)
+
+    ratio_df = pd.DataFrame(per_symbol_ratio).sort_index()
+    ratio_df = ratio_df.ffill().dropna(how="all")
+    if ratio_df.empty:
+        return PortfolioHoldoutResult(trades=trades_by_symbol)
+
+    portfolio_ratio = ratio_df.mean(axis=1, skipna=True)
+    portfolio_ratio = portfolio_ratio.dropna()
+    if portfolio_ratio.empty:
+        return PortfolioHoldoutResult(trades=trades_by_symbol)
+    portfolio_ratio.name = "portfolio_ratio"
+
+    portfolio_equity = portfolio_ratio * base_equity
+    portfolio_equity.name = "portfolio_equity"
+
+    aligned_equity: Dict[str, pd.Series] = {}
+    aligned_ratio: Dict[str, pd.Series] = {}
+    for sym, series in per_symbol_equity.items():
+        aligned_equity[sym] = series.reindex(portfolio_equity.index).ffill()
+    for sym, series in per_symbol_ratio.items():
+        aligned_ratio[sym] = series.reindex(portfolio_ratio.index).ffill()
+
+    return PortfolioHoldoutResult(
+        equity=portfolio_equity,
+        ratio=portfolio_ratio,
+        per_symbol_equity=aligned_equity,
+        per_symbol_ratio=aligned_ratio,
+        trades=trades_by_symbol,
+    )
 
 
 def _normalize_symbols(seq) -> list[str]:
@@ -1725,9 +1980,16 @@ with best_score_col:
 with best_params_col:
     best_params_placeholder = st.empty()
 
-st.markdown("### Holdout equity (outside training window)")
-holdout_chart_placeholder = st.empty()
+st.markdown("### Holdout diagnostics")
+diag_cols = st.columns([1.8, 1.2], gap="large")
+with diag_cols[0]:
+    holdout_equity_placeholder = st.empty()
+with diag_cols[1]:
+    holdout_heatmap_placeholder = st.empty()
 holdout_status_placeholder = st.empty()
+
+st.markdown("### Trade lifecycle timeline")
+holdout_timeline_placeholder = st.empty()
 
 st.markdown("### Generation summary")
 gen_summary_placeholder = st.empty()
@@ -1760,11 +2022,20 @@ if best_params_state:
 else:
     best_params_placeholder.info("Waiting for evaluations…")
 
-holdout_history_state = st.session_state.get("adapter_holdout_history") or []
-# (chart rendered by holdout_chart helper)
 # ---------- Results hydration & status ----------
-holdout_status_state = st.session_state.get("adapter_holdout_status") or ("info",
-                                                                          "Holdout equity will appear when a best candidate is found.")
+equity_series_state = st.session_state.get(HOLDOUT_EQUITY_KEY)
+benchmark_series_state = st.session_state.get(HOLDOUT_BENCHMARK_KEY)
+returns_series_state = st.session_state.get(HOLDOUT_RETURNS_KEY)
+trades_df_state = st.session_state.get(HOLDOUT_TRADES_KEY)
+
+_render_holdout_equity_chart(holdout_equity_placeholder, equity_series_state, benchmark_series_state)
+_render_holdout_heatmap(holdout_heatmap_placeholder, returns_series_state)
+_render_trade_timeline(holdout_timeline_placeholder, trades_df_state)
+
+holdout_status_state = st.session_state.get("adapter_holdout_status") or (
+    "info",
+    "Holdout diagnostics will appear once a best candidate evaluates on the holdout window.",
+)
 status_kind, status_msg = holdout_status_state
 if status_kind == "success":
     holdout_status_placeholder.success(status_msg)
@@ -1807,6 +2078,11 @@ if run_btn:
     st.session_state["adapter_gen_history"] = []
     st.session_state["adapter_best_tracker"] = dict(best_tracker)
 
+    st.session_state[HOLDOUT_EQUITY_KEY] = None
+    st.session_state[HOLDOUT_RETURNS_KEY] = None
+    st.session_state[HOLDOUT_BENCHMARK_KEY] = None
+    st.session_state[HOLDOUT_TRADES_KEY] = None
+
     eval_table_placeholder.empty()
     best_score_placeholder.metric("Best score", "—")
     best_params_placeholder.info("Waiting for evaluations…")
@@ -1832,28 +2108,60 @@ if run_btn:
         f"Testing on holdout window {holdout_start.date().isoformat()} → {holdout_end.date().isoformat()}",
     )
 
-    def _hc_engine(params, data, starting_equity):
-        series = _portfolio_equity_curve(
-            strategy_dotted,
-            tickers,
-            holdout_start,
-            holdout_end,
-            float(starting_equity),
-            params,
-        )
-        return pd.DataFrame({"equity": series})
-
-    init_chart(
-        placeholder=holdout_chart_placeholder,
-        starting_equity=float(equity),
-        holdout_start=holdout_start,
-        holdout_end=holdout_end,
-        loader_fn=lambda **kwargs: {},  # unused by _hc_engine
-        engine_fn=_hc_engine,
-        symbols=tickers,
-        max_curves=8,
-    )
     st.session_state["_hc_last_score"] = None
+
+    def _load_benchmark_equity(target_index: pd.DatetimeIndex) -> pd.Series | None:
+        try:
+            bench = get_benchmark_total_return(start=holdout_start, end=holdout_end)
+        except Exception:
+            bench = None
+        if bench is None or bench.empty:
+            return None
+        bench = _ensure_dt_index(bench.astype(float))
+        bench = bench.reindex(target_index.union(bench.index)).ffill()
+        bench = bench.reindex(target_index).ffill().dropna()
+        if bench.empty:
+            return None
+        bench_equity = bench * float(equity)
+        bench_equity.name = "benchmark_equity"
+        return bench_equity
+
+    def _update_holdout_visuals(gen_idx: int, best_score_val: float, params: Dict[str, Any]) -> None:
+        try:
+            result = _portfolio_equity_curve(
+                strategy_dotted,
+                tickers,
+                holdout_start,
+                holdout_end,
+                float(equity),
+                params,
+            )
+        except Exception:
+            return
+
+        equity_series = getattr(result, "equity", pd.Series(dtype=float))
+        if equity_series is None or equity_series.empty:
+            return
+
+        equity_series = _ensure_dt_index(equity_series.astype(float))
+        returns_series = equity_series.pct_change().replace([np.inf, -np.inf], np.nan).fillna(0.0)
+        benchmark_series = _load_benchmark_equity(equity_series.index)
+        trades_df = _flatten_trades(getattr(result, "trades", {}))
+
+        st.session_state[HOLDOUT_EQUITY_KEY] = equity_series
+        st.session_state[HOLDOUT_RETURNS_KEY] = returns_series
+        st.session_state[HOLDOUT_BENCHMARK_KEY] = benchmark_series
+        st.session_state[HOLDOUT_TRADES_KEY] = trades_df
+
+        status_suffix = f" (Gen {gen_idx}, score={best_score_val:.3f})" if isinstance(best_score_val, (int, float)) else ""
+        st.session_state["adapter_holdout_status"] = (
+            "success",
+            f"Holdout window {holdout_start.date().isoformat()} → {holdout_end.date().isoformat()}{status_suffix}",
+        )
+
+        _render_holdout_equity_chart(holdout_equity_placeholder, equity_series, benchmark_series)
+        _render_holdout_heatmap(holdout_heatmap_placeholder, returns_series)
+        _render_trade_timeline(holdout_timeline_placeholder, trades_df)
 
     # ---- Build EA param space from UI bounds ----
     cfg = ea_cfg
@@ -2026,7 +2334,11 @@ if run_btn:
             should_push = (last_plotted is None) or (isinstance(best_score_gen, (int, float)) and best_score_gen > last_plotted)
             if should_push and isinstance(best_score_gen, (int, float)) and best_params_gen:
                 try:
-                    on_generation_end(int(ctx.get("gen", 0)), float(best_score_gen), dict(best_params_gen))
+                    _update_holdout_visuals(
+                        int(ctx.get("gen", 0)),
+                        float(best_score_gen),
+                        dict(best_params_gen),
+                    )
                     st.session_state["_hc_last_score"] = float(best_score_gen)
                 except Exception:
                     pass

--- a/pages/2_Model_Builder.py
+++ b/pages/2_Model_Builder.py
@@ -765,8 +765,10 @@ def _render_holdout_heatmap(
     returns: pd.Series | None,
     x_range: Tuple[pd.Timestamp, pd.Timestamp] | None = None,
 ) -> None:
+    container = placeholder.container()
+
     if returns is None or returns.dropna().empty:
-        placeholder.info("Rolling performance heatmap will populate after a completed holdout run.")
+        container.info("Rolling performance heatmap will populate after a completed holdout run.")
         return
 
     returns = _ensure_dt_index(returns.copy())
@@ -783,7 +785,7 @@ def _render_holdout_heatmap(
 
     heatmap_df = pd.DataFrame(metrics).dropna(how="all")
     if heatmap_df.empty:
-        placeholder.info("Not enough overlapping holdout data to compute rolling performance windows yet.")
+        container.info("Not enough overlapping holdout data to compute rolling performance windows yet.")
         return
 
     heatmap_df = heatmap_df.fillna(np.nan)
@@ -813,7 +815,18 @@ def _render_holdout_heatmap(
     )
     if x_range is not None:
         fig.update_layout(xaxis=dict(range=[x_range[0], x_range[1]]))
-    placeholder.plotly_chart(fig, use_container_width=True)
+    container.plotly_chart(fig, use_container_width=True)
+    container.markdown(
+        """
+        **How to read this heatmap**
+
+        * Each row represents a rolling window (e.g., 5-day) of compounded strategy returns.
+        * Colors encode the annualized return for that window—greens indicate positive momentum, yellows are flat, and reds
+          highlight stretches of drawdown.
+        * Line up the vertical date bands with the equity curve above and trade timeline below to spot which clusters of
+          trades produced the strongest or weakest performance at different horizons.
+        """
+    )
 
 
 def _render_trade_timeline(

--- a/pages/2_Model_Builder.py
+++ b/pages/2_Model_Builder.py
@@ -606,6 +606,8 @@ HOLDOUT_BENCHMARK_KEY = "adapter_holdout_benchmark_series"
 HOLDOUT_RETURNS_KEY = "adapter_holdout_returns_series"
 HOLDOUT_TRADES_KEY = "adapter_holdout_trades"
 
+HOLDOUT_CHART_MARGIN = dict(l=80, r=30, t=40, b=30)
+
 
 @dataclass
 class PortfolioHoldoutResult:
@@ -747,10 +749,11 @@ def _render_holdout_equity_chart(
 
     fig.update_layout(
         title="Holdout equity (anchored at starting capital)",
-        margin=dict(l=10, r=10, t=40, b=10),
+        margin=HOLDOUT_CHART_MARGIN,
         legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1.0),
         xaxis_title="Date",
         yaxis_title="Equity ($)",
+        yaxis_title_standoff=10,
     )
     if x_range is not None:
         fig.update_layout(xaxis=dict(range=[x_range[0], x_range[1]]))
@@ -803,8 +806,10 @@ def _render_holdout_heatmap(
     )
     fig.update_layout(
         title="Rolling performance heatmap",
-        margin=dict(l=10, r=10, t=40, b=30),
+        margin=HOLDOUT_CHART_MARGIN,
         xaxis_title="Date",
+        yaxis_title="Rolling window",
+        yaxis_title_standoff=10,
     )
     if x_range is not None:
         fig.update_layout(xaxis=dict(range=[x_range[0], x_range[1]]))
@@ -849,8 +854,11 @@ def _render_trade_timeline(
     )
     fig.update_layout(
         title="Trade lifecycle timeline",
-        margin=dict(l=10, r=10, t=40, b=30),
+        margin=HOLDOUT_CHART_MARGIN,
         coloraxis_colorbar=dict(title="Return (%)"),
+        xaxis_title="Date",
+        yaxis_title="Symbol",
+        yaxis_title_standoff=10,
     )
     if x_range is not None:
         fig.update_layout(xaxis=dict(range=[x_range[0], x_range[1]]))


### PR DESCRIPTION
## Summary
- replace the holdout equity widget with a starting-capital anchored equity chart that includes an index benchmark
- add rolling performance heatmap and trade lifecycle timeline panels fed by the EA holdout run
- update the shared holdout_equity helper to use starting equity anchoring so downstream tools see the same curve shape

## Testing
- pytest tests/test_holdout_equity.py

------
https://chatgpt.com/codex/tasks/task_e_68e6ecfe7258832ab75b03111ecd036c