### PR TITLE
Warm ATR backtests with sufficient historical padding

### DIFF
--- a/docs/model_builder_visualization_ideas.md
+++ b/docs/model_builder_visualization_ideas.md
@@ -1,0 +1,41 @@
+# Model Builder Visualization Enhancements
+
+The existing holdout equity curve normalizes per-symbol P\&L streams by the first non-zero observation. When many strategies
+report a zero balance until the first closing trade, this produces a flat "no trades" segment at the start of the chart. To give
+traders a clearer picture of out-of-sample behaviour, consider replacing or augmenting that chart with the following views.
+
+## 1. Starting-Equity Anchored Equity Curve
+- Anchor the equity curve to the configured starting equity (or the first timestamp) rather than the first non-zero trade.
+- Plot both the strategy equity and the benchmark on the same axes to highlight relative performance from day one.
+- Optional: add shading for periods where the strategy is outperforming/underperforming the benchmark.
+
+## 2. Rolling Performance Heatmap
+- Render a 2D heatmap where the x-axis is time and the y-axis is a rolling window length (e.g., 5, 10, 20, 60 trading days).
+- Each cell shows the annualized return or Sharpe ratio for that window, revealing momentum regimes at a glance.
+- Useful for spotting when the strategy repeatedly stalls or accelerates in the holdout.
+
+## 3. Trade Lifecycle Timeline
+- Plot each fill as a horizontal bar spanning entry to exit, positioned vertically by symbol or strategy leg.
+- Encode profit/loss with color and bar thickness with position size.
+- Provides intuition on trade overlap, holding periods, and whether inactivity stems from filters or market conditions.
+
+## 4. Drawdown vs. Exposure Scatter
+- Each point represents a trading day (or hour) with x = net exposure (% of capital deployed) and y = current drawdown.
+- Helps diagnose whether large drawdowns coincide with maxed-out exposure or leverage.
+- Can be extended with marginal histograms to emphasize distribution tails.
+
+## 5. Cumulative Net Exposure Chart
+- Stack area chart showing long, short, and cash allocations through time.
+- When paired with the equity curve, clarifies whether flat performance stems from being flat/cash or from losing trades.
+
+## 6. Trade Frequency & Hit Rate Dashboard
+- Combine two small multiples: (a) rolling trade count per period, (b) rolling win rate / expectancy.
+- Signals whether the strategy is encountering fewer opportunities or simply underperforming on existing trades.
+
+## Layout Suggestions
+- **Two-column layout:** equity curve (anchored) on the left, dashboard of rolling stats on the right.
+- **Tabbed interface:** separate tabs for equity, trade lifecycle, and diagnostics to avoid clutter while keeping related charts a single click away.
+- **Small multiples:** align charts vertically with shared x-axis (time) for quick cross-comparison.
+
+Implementing even one of these replacements will help traders understand whether a flat holdout segment reflects inactivity,
+risk management, or simply delayed trade closures.

--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
+from pandas.tseries.offsets import BDay
 
 from src.backtest import prob_gate
 
@@ -476,6 +477,17 @@ def backtest_atr_breakout(
         extra_params = {k: params_dict[k] for k in params_dict if k not in known}
         params = ATRParams(**params_core)
 
+    start_ts = pd.Timestamp(start)
+    if start_ts.tzinfo is None:
+        start_ts = start_ts.tz_localize("UTC")
+    else:
+        start_ts = start_ts.tz_convert("UTC")
+    end_ts = pd.Timestamp(end)
+    if end_ts.tzinfo is None:
+        end_ts = end_ts.tz_localize("UTC")
+    else:
+        end_ts = end_ts.tz_convert("UTC")
+
     entry_mode_extra = str(extra_params.get("entry_mode", "") or "").strip().lower()
     dip_overlay_raw: Dict[str, Any] = {}
     if isinstance(extra_params.get("dip_overlay"), dict):
@@ -536,6 +548,52 @@ def backtest_atr_breakout(
         extra_params["dip_overlay"] = dict(dip_overlay_config)
     else:
         dip_overlay_config = dict(DIP_OVERLAY_DEFAULTS)
+
+    trend_filter_ma = int(max(0, _coerce_float(getattr(params, "trend_filter_ma", 0), 0.0)))
+    trend_filter_slope_lookback = int(
+        max(0, _coerce_float(getattr(params, "trend_filter_slope_lookback", 0), 0.0))
+    )
+    trend_filter_slope_threshold = _coerce_float(
+        getattr(params, "trend_filter_slope_threshold", 0.0), 0.0
+    )
+    trend_filter_exit = bool(getattr(params, "trend_filter_exit", False))
+
+    vol_target_enabled = bool(getattr(params, "vol_target_enabled", False))
+    vol_target_target_pct = max(0.0, _coerce_float(getattr(params, "vol_target_target_pct", 0.0), 0.0))
+    vol_target_min_leverage = max(
+        0.0, _coerce_float(getattr(params, "vol_target_min_leverage", 0.0), 0.0)
+    )
+    vol_target_max_leverage = max(
+        vol_target_min_leverage,
+        _coerce_float(getattr(params, "vol_target_max_leverage", 1.0), 1.0),
+    )
+    vol_target_atr_window = int(
+        max(1, _coerce_float(getattr(params, "vol_target_atr_window", params.atr_n), params.atr_n))
+    )
+
+    warmup_candidates = [
+        int(params.breakout_n),
+        int(params.exit_n),
+        int(params.atr_n),
+        trend_filter_ma,
+        trend_filter_ma + trend_filter_slope_lookback,
+    ]
+    if vol_target_enabled:
+        warmup_candidates.append(vol_target_atr_window)
+    if dip_overlay_enabled:
+        warmup_candidates.append(
+            int(dip_overlay_config.get("trend_ma", DIP_OVERLAY_DEFAULTS["trend_ma"]))
+        )
+        warmup_candidates.append(
+            int(dip_overlay_config.get("dip_lookback_high", DIP_OVERLAY_DEFAULTS["dip_lookback_high"]))
+        )
+        warmup_candidates.append(DIP_RSI_PERIOD)
+    warmup_bars = max([c for c in warmup_candidates if c is not None], default=0)
+    warmup_padding = max(0, int(math.ceil(warmup_bars * 0.1)))
+    total_warmup = warmup_bars + (warmup_padding if warmup_bars > 0 else 0)
+    warmup_start = start_ts
+    if total_warmup > 0:
+        warmup_start = start_ts - BDay(total_warmup)
 
     delay_candidate = _coerce_float(getattr(params, "delay_bars", 0), 0.0)
     if delay_bars is not None:
@@ -603,11 +661,21 @@ def backtest_atr_breakout(
         cost_model.enabled = False
     enable_costs = bool(cost_model.enabled or phase0_cost_model.enabled)
 
-    df = get_ohlcv(symbol, start, end).copy()
+    df = get_ohlcv(symbol, warmup_start.to_pydatetime(), end_ts.to_pydatetime()).copy()
+    aligned_start = start_ts
+    aligned_end = end_ts
+    if isinstance(df.index, pd.DatetimeIndex):
+        if df.index.tz is None:
+            aligned_start = start_ts.tz_convert("UTC").tz_localize(None)
+            aligned_end = end_ts.tz_convert("UTC").tz_localize(None)
+        else:
+            aligned_start = start_ts.tz_convert(df.index.tz)
+            aligned_end = end_ts.tz_convert(df.index.tz)
+    df = df.loc[: aligned_end]
     base_meta = {
         "symbol": symbol,
-        "start": pd.Timestamp(start),
-        "end": pd.Timestamp(end),
+        "start": start_ts,
+        "end": end_ts,
         "params": dict(params.__dict__),
         "extra_params": extra_params,
         "execution": execution,
@@ -617,6 +685,9 @@ def backtest_atr_breakout(
         "phase0_cost_model": phase0_cost_model.as_dict(),
         "notes": "ATR breakout long-only reference engine",
     }
+    if warmup_start < start_ts:
+        base_meta["data_start"] = warmup_start
+        base_meta["warmup_bars"] = total_warmup
 
     if df.empty:
         empty_series = pd.Series(dtype=float)
@@ -676,9 +747,6 @@ def backtest_atr_breakout(
         vol_target_min_leverage,
         _coerce_float(getattr(params, "vol_target_max_leverage", 1.0), 1.0),
     )
-    vol_target_atr_window = int(
-        max(1, _coerce_float(getattr(params, "vol_target_atr_window", params.atr_n), params.atr_n))
-    )
     vol_target_active = vol_target_enabled and vol_target_target_pct > 0.0
     if vol_target_active:
         if vol_target_atr_window != params.atr_n:
@@ -699,14 +767,6 @@ def backtest_atr_breakout(
     else:
         vol_target_scale_series = pd.Series(1.0, index=df.index, dtype=float)
         vol_target_atr_pct = pd.Series(0.0, index=df.index, dtype=float)
-    trend_filter_ma = int(max(0, _coerce_float(getattr(params, "trend_filter_ma", 0), 0.0)))
-    trend_filter_slope_lookback = int(
-        max(0, _coerce_float(getattr(params, "trend_filter_slope_lookback", 0), 0.0))
-    )
-    trend_filter_slope_threshold = _coerce_float(
-        getattr(params, "trend_filter_slope_threshold", 0.0), 0.0
-    )
-    trend_filter_exit = bool(getattr(params, "trend_filter_exit", False))
     trend_filter_enabled = (trend_filter_ma > 1) or (trend_filter_slope_lookback > 0)
     trend_filter_price_ok = pd.Series(True, index=df.index, dtype=bool)
     trend_filter_slope_ok = pd.Series(True, index=df.index, dtype=bool)
@@ -810,6 +870,55 @@ def backtest_atr_breakout(
         dip_cooldown_days = int(
             dip_overlay_config.get("dip_cooldown_days", DIP_OVERLAY_DEFAULTS["dip_cooldown_days"])
         )
+
+    df = df.loc[(df.index >= aligned_start) & (df.index <= aligned_end)].copy()
+    if df.empty:
+        empty_series = pd.Series(dtype=float)
+        meta = dict(base_meta)
+        meta["costs"] = {
+            "enabled": enable_costs,
+            "summary": {
+                "turnover": 0.0,
+                "weighted_slippage_bps": 0.0,
+                "weighted_fees_bps": 0.0,
+                "pre_cost_cagr": 0.0,
+                "post_cost_cagr": 0.0,
+                "annualized_drag": 0.0,
+                "total_cost": 0.0,
+            },
+        }
+        return {
+            "equity": empty_series,
+            "daily_returns": empty_series,
+            "trades": [],
+            "equity_pre_cost": empty_series,
+            "daily_returns_pre_cost": empty_series,
+            "trades_df": pd.DataFrame(),
+            "meta": meta,
+        }
+
+    align_index = df.index
+    atr = atr.reindex(align_index)
+    roll_high = roll_high.reindex(align_index)
+    roll_low = roll_low.reindex(align_index)
+    prior_high = prior_high.reindex(align_index)
+    long_base = long_base.reindex(align_index).fillna(False)
+    buffer_gate = buffer_gate.reindex(align_index).fillna(False)
+    long_signal = long_signal.reindex(align_index).fillna(False)
+    raw_long_breakout = raw_long_breakout.reindex(align_index).fillna(False)
+    trend_filter_price_ok = trend_filter_price_ok.reindex(align_index).fillna(False)
+    trend_filter_slope_ok = trend_filter_slope_ok.reindex(align_index).fillna(False)
+    trend_filter_ok = trend_filter_ok.reindex(align_index).fillna(False)
+    vol_target_scale_series = vol_target_scale_series.reindex(align_index).fillna(1.0)
+    vol_target_atr_pct = vol_target_atr_pct.reindex(align_index).fillna(0.0)
+    if gate_probabilities is not None:
+        gate_probabilities = gate_probabilities.reindex(align_index)
+    if dip_overlay_active:
+        dip_trend_ok = dip_trend_ok.reindex(align_index).fillna(False)
+        dip_depth_ok = dip_depth_ok.reindex(align_index).fillna(False)
+        dip_rsi_ok = dip_rsi_ok.reindex(align_index).fillna(False)
+        dip_confirm_ok = dip_confirm_ok.reindex(align_index).fillna(False)
+        dip_conditions_ok = dip_conditions_ok.reindex(align_index).fillna(False)
 
     in_pos = False
     entry_idx: Optional[int] = None

--- a/tests/test_backtest_warmup.py
+++ b/tests/test_backtest_warmup.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pandas as pd
+
+from src.backtest.engine import ATRParams, backtest_atr_breakout
+
+
+def test_backtest_requests_warmup_history(monkeypatch):
+    idx = pd.bdate_range("2023-01-02", periods=400, tz="UTC")
+    base_price = pd.Series(100.0 + np.linspace(0, 40, len(idx)), index=idx)
+    frame = pd.DataFrame(
+        {
+            "open": base_price,
+            "high": base_price + 1.0,
+            "low": base_price - 1.0,
+            "close": base_price + 0.25,
+            "volume": 1_000,
+        }
+    )
+
+    captured: dict[str, pd.Timestamp] = {}
+
+    def fake_loader(symbol, start, end):
+        captured["start"] = pd.Timestamp(start)
+        captured["end"] = pd.Timestamp(end)
+        start_ts = pd.Timestamp(start)
+        end_ts = pd.Timestamp(end)
+        if start_ts.tzinfo is None:
+            start_ts = start_ts.tz_localize("UTC")
+        else:
+            start_ts = start_ts.tz_convert("UTC")
+        if end_ts.tzinfo is None:
+            end_ts = end_ts.tz_localize("UTC")
+        else:
+            end_ts = end_ts.tz_convert("UTC")
+        return frame.loc[start_ts:end_ts]
+
+    monkeypatch.setattr("src.backtest.engine.get_ohlcv", fake_loader)
+
+    start = pd.Timestamp("2023-11-01", tz="UTC")
+    end = pd.Timestamp("2023-12-29", tz="UTC")
+    params = ATRParams(breakout_n=30, exit_n=10, atr_n=20, atr_multiple=1.0)
+
+    result = backtest_atr_breakout("TEST", start, end, 100_000.0, params)
+
+    requested_start = captured["start"]
+    if requested_start.tzinfo is None:
+        requested_start = requested_start.tz_localize("UTC")
+    else:
+        requested_start = requested_start.tz_convert("UTC")
+    assert requested_start < start
+
+    business_days = len(
+        pd.bdate_range(
+            requested_start.tz_convert(None),
+            start.tz_convert(None),
+            inclusive="left",
+        )
+    )
+    assert business_days >= params.breakout_n
+
+    equity_index = result["equity"].index
+    assert len(equity_index) > 0
+    assert equity_index[0] == start
+
+    meta = result["meta"]
+    meta_start = pd.Timestamp(meta.get("data_start"))
+    if meta_start.tzinfo is None:
+        meta_start = meta_start.tz_localize("UTC")
+    else:
+        meta_start = meta_start.tz_convert("UTC")
+    assert meta_start <= requested_start
+    assert meta.get("warmup_bars") >= params.breakout_n


### PR DESCRIPTION
## Summary
- add a configurable warmup window to the ATR breakout engine so data loaders fetch enough pre-start history to seed indicators
- align the post-fetch slicing with the data frame timezone and expose the captured warmup window in the backtest metadata
- add regression coverage around the warmup behaviour and update the probability-gate test harness to return UTC-indexed data

## Testing
- pytest tests/test_backtest_warmup.py tests/test_prob_gate_backtest.py tests/test_holdout_equity.py

------
https://chatgpt.com/codex/tasks/task_e_68e6ecfe7258832ab75b03111ecd036c