### PR TITLE
Disable warmup fetch during training runs

### DIFF
--- a/src/models/_warmup.py
+++ b/src/models/_warmup.py
@@ -1,0 +1,4 @@
+"""Internal helpers for coordinating warmup behaviour across strategy callers."""
+
+DISABLE_WARMUP_FLAG = "__disable_warmup_fetch__"
+

--- a/src/models/atr_breakout.py
+++ b/src/models/atr_breakout.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any, Dict, Tuple
 
 from src.backtest.engine import ATRParams, backtest_atr_breakout, CostModel
+from src.models._warmup import DISABLE_WARMUP_FLAG
 from src.backtest.metrics import compute_core_metrics
 
 MODEL_KEY = "atr_breakout"
@@ -30,12 +31,15 @@ def run_strategy(
 ) -> Dict:
     p, exec_mode = _split_execution(params)
     model_key = MODEL_KEY
+    disable_warmup = False
     if isinstance(p, dict):
         payload = dict(p)
+        disable_warmup = bool(payload.pop(DISABLE_WARMUP_FLAG, False))
         model_key = str(payload.pop("model_key", MODEL_KEY) or MODEL_KEY)
         p = ATRParams(**payload)
     else:
         model_key = getattr(p, "model_key", MODEL_KEY) if hasattr(p, "model_key") else MODEL_KEY
+        disable_warmup = bool(getattr(p, DISABLE_WARMUP_FLAG, False))
     enable_costs = bool(getattr(p, "enable_costs", False))
     delay_bars = int(getattr(p, "delay_bars", 0) or 0)
     commission_override = getattr(p, "commission_bps", None)
@@ -67,6 +71,7 @@ def run_strategy(
         enable_costs=enable_costs,
         delay_bars=delay_bars,
         cost_model=cost_model,
+        use_warmup=not disable_warmup,
     )
 
 

--- a/src/models/atr_dip_breakout.py
+++ b/src/models/atr_dip_breakout.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, Tuple
 
 from src.backtest.engine import ATRParams, backtest_atr_breakout, CostModel
+from src.models._warmup import DISABLE_WARMUP_FLAG
 
 MODEL_KEY = "atr_dip_overlay"
 
@@ -66,9 +67,11 @@ def run_strategy(
     payload, exec_mode = _split_execution(params)
     model_key = MODEL_KEY
     overlay_cfg: Dict[str, Any] = dict(DEFAULT_DIP_OVERLAY)
+    disable_warmup = False
 
     if isinstance(payload, dict):
         params_dict = dict(payload)
+        disable_warmup = bool(params_dict.pop(DISABLE_WARMUP_FLAG, False))
         model_key = str(params_dict.pop("model_key", MODEL_KEY) or MODEL_KEY)
         params_dict.pop("entry_mode", None)
         overlay_cfg = _prepare_overlay(params_dict)
@@ -77,6 +80,7 @@ def run_strategy(
         p = ATRParams(**params_dict)
     elif isinstance(payload, ATRParams):
         p = payload
+        disable_warmup = bool(getattr(p, DISABLE_WARMUP_FLAG, False))
     else:
         p = ATRParams()
 
@@ -115,4 +119,5 @@ def run_strategy(
         enable_costs=enable_costs,
         delay_bars=delay_bars,
         cost_model=cost_model,
+        use_warmup=not disable_warmup,
     )


### PR DESCRIPTION
## Summary
- add a shared flag to signal when strategy wrappers should skip pre-backtest warmup fetches
- have the general trainer pass that flag so EA training requests only the requested window
- guard the engine warmup logic so callers can opt out without breaking metadata

## Testing
- pytest tests/test_strategy_adapter_pipeline.py -q
- pytest tests/test_backtest_warmup.py -q
- pytest tests/test_prob_gate_backtest.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e7c2d6c6ac832a9ad67c8495bf246d