### PR TITLE
Enhance holdout equity chart with benchmark context

### DIFF
--- a/src/utils/holdout_chart.py
+++ b/src/utils/holdout_chart.py
@@ -1,11 +1,14 @@
 from importlib import import_module
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List
 
 from datetime import date, datetime
 
+import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
+
+from src.storage import get_benchmark_total_return
 
 
 # ---- Internal state keys ------------------------------------------------------
@@ -19,7 +22,8 @@ def _ss_key(name: str) -> str:
 # ---- Rendering ----------------------------------------------------------------
 
 def _render(curves: List[Dict[str, Any]], placeholder: st.delta_generator.DeltaGenerator) -> None:
-    """Render blank axes when no curves; otherwise grey old lines (no legend) and show legend for latest only."""
+    """Render holdout curves with benchmark + relative performance shading when available."""
+
     fig = go.Figure()
 
     if not curves:
@@ -28,20 +32,24 @@ def _render(curves: List[Dict[str, Any]], placeholder: st.delta_generator.DeltaG
             margin=dict(l=10, r=10, t=35, b=10),
             showlegend=False,
             xaxis_title="Date",
-            yaxis_title="Equity",
+            yaxis_title="Equity ($)",
         )
-        # Add empty trace so axes render
         fig.add_trace(go.Scatter(x=[], y=[], mode="lines", showlegend=False))
         _plot(fig, placeholder)
         return
 
-    # Old curves (all except last) -> grey, no legend
+    # Plot historical best curves in grey for context (strategy + optional benchmark).
     if len(curves) > 1:
         for run in curves[:-1]:
+            x_vals = _to_datetime_list(run.get("x"))
+            strategy_vals = _to_float_array(run.get("equity") or run.get("y"))
+            if not x_vals or len(x_vals) != len(strategy_vals):
+                continue
+
             fig.add_trace(
                 go.Scatter(
-                    x=run.get("x", []),
-                    y=run.get("y", []),
+                    x=x_vals,
+                    y=[None if np.isnan(v) else float(v) for v in strategy_vals],
                     mode="lines",
                     line=dict(width=1.0, color="rgba(150,150,150,0.55)"),
                     name="",
@@ -50,32 +58,117 @@ def _render(curves: List[Dict[str, Any]], placeholder: st.delta_generator.DeltaG
                 )
             )
 
-    # Current best = last item -> normal color, legend shown
+            bench_vals = _to_float_array(run.get("benchmark"))
+            if len(bench_vals) == len(strategy_vals) and np.isfinite(bench_vals).any():
+                fig.add_trace(
+                    go.Scatter(
+                        x=x_vals,
+                        y=[None if np.isnan(v) else float(v) for v in bench_vals],
+                        mode="lines",
+                        line=dict(width=1.0, color="rgba(120,120,120,0.35)", dash="dot"),
+                        name="",
+                        showlegend=False,
+                        hoverinfo="skip",
+                    )
+                )
+
     best = curves[-1]
-    best_gen = best.get("gen", None)
+    best_gen = best.get("gen")
     best_label = best.get("label") or (f"Gen {best_gen}" if best_gen is not None else "Current best")
-    best_score = best.get("score", None)
+    best_score = best.get("score")
     legend_name = best_label if best_score is None else f"{best_label} (score={best_score:.3f})"
 
-    fig.add_trace(
-        go.Scatter(
-            x=best.get("x", []),
-            y=best.get("y", []),
-            mode="lines",
-            line=dict(width=2.4),
-            name=legend_name,
-            showlegend=True,
-        )
-    )
+    x_vals = _to_datetime_list(best.get("x"))
+    strategy_vals = _to_float_array(best.get("equity") or best.get("y"))
+    bench_vals = _to_float_array(best.get("benchmark"))
+    bench_label = best.get("benchmark_label", "Benchmark")
 
-    # Title reflects current best generation
+    has_strategy = bool(x_vals) and len(x_vals) == len(strategy_vals)
+    has_benchmark = has_strategy and len(bench_vals) == len(strategy_vals) and np.isfinite(bench_vals).any()
+
+    if has_benchmark:
+        valid_points = np.array([x is not None for x in x_vals], dtype=bool)
+        strategy_clean = np.where(np.isfinite(strategy_vals), strategy_vals, np.nan)
+        bench_clean = np.where(np.isfinite(bench_vals), bench_vals, np.nan)
+        diff = np.where(np.isfinite(strategy_clean) & np.isfinite(bench_clean), strategy_clean - bench_clean, np.nan)
+        outperform_mask = np.where(np.isfinite(diff) & (diff >= 0) & valid_points, True, False)
+        underperform_mask = np.where(np.isfinite(diff) & (diff < 0) & valid_points, True, False)
+
+        def _add_fill(mask: np.ndarray, name: str, color: str) -> None:
+            if not mask.any():
+                return
+            upper: List[float | None] = []
+            lower: List[float | None] = []
+            custom: List[float | None] = []
+            for is_active, strat_val, bench_val, delta in zip(mask, strategy_clean, bench_clean, diff):
+                if not is_active or not np.isfinite(strat_val) or not np.isfinite(bench_val):
+                    upper.append(None)
+                    lower.append(None)
+                    custom.append(None)
+                    continue
+                upper.append(float(max(strat_val, bench_val)))
+                lower.append(float(min(strat_val, bench_val)))
+                custom.append(float(delta))
+
+            fig.add_trace(
+                go.Scatter(
+                    x=x_vals,
+                    y=upper,
+                    mode="lines",
+                    line=dict(width=0),
+                    hoverinfo="skip",
+                    showlegend=False,
+                    connectgaps=False,
+                )
+            )
+            fig.add_trace(
+                go.Scatter(
+                    x=x_vals,
+                    y=lower,
+                    mode="lines",
+                    fill="tonexty",
+                    fillcolor=color,
+                    line=dict(width=0),
+                    name=name,
+                    showlegend=True,
+                    connectgaps=False,
+                    customdata=custom,
+                    hovertemplate="Date=%{x|%Y-%m-%d}<br>Diff=$%{customdata:.2f}<extra></extra>",
+                )
+            )
+
+        _add_fill(outperform_mask, "Outperformance", "rgba(40, 167, 69, 0.25)")
+        _add_fill(underperform_mask, "Underperformance", "rgba(220, 53, 69, 0.25)")
+
+        fig.add_trace(
+            go.Scatter(
+                x=x_vals,
+                y=[None if np.isnan(v) else float(v) for v in bench_clean],
+                mode="lines",
+                name=bench_label,
+                line=dict(width=1.8, color="#6c757d", dash="dash"),
+            )
+        )
+
+    if has_strategy:
+        fig.add_trace(
+            go.Scatter(
+                x=x_vals,
+                y=[None if np.isnan(v) else float(v) for v in strategy_vals],
+                mode="lines",
+                line=dict(width=2.4, color="#1f78b4"),
+                name=legend_name,
+                showlegend=True,
+            )
+        )
+
     title = best_label if best_gen is not None else "Holdout equity (current best)"
     fig.update_layout(
         title=title,
         margin=dict(l=10, r=10, t=35, b=10),
         showlegend=True,
         xaxis_title="Date",
-        yaxis_title="Equity",
+        yaxis_title="Equity ($)",
         legend=dict(
             orientation="h",
             yanchor="bottom",
@@ -97,6 +190,143 @@ def _plot(fig: "go.Figure", placeholder: st.delta_generator.DeltaGenerator) -> N
     placeholder.plotly_chart(fig, use_container_width=True, key=render_key)
 
 
+# ---- Helpers ------------------------------------------------------------------
+
+def _blank_curve() -> Dict[str, Any]:
+    return {"x": [], "equity": [], "benchmark": None, "benchmark_label": "Benchmark"}
+
+
+def _to_float_array(values: Any) -> np.ndarray:
+    arr: List[float] = []
+    if values is None:
+        return np.array(arr, dtype=float)
+    for val in values:
+        try:
+            num = float(val)
+        except (TypeError, ValueError):
+            arr.append(np.nan)
+        else:
+            arr.append(num if np.isfinite(num) else np.nan)
+    return np.array(arr, dtype=float)
+
+
+def _to_datetime_list(values: Any) -> List[Any]:
+    if values is None:
+        return []
+    try:
+        idx = pd.to_datetime(list(values), errors="coerce")
+    except Exception:
+        return []
+    out: List[Any] = []
+    for ts in idx:
+        if pd.isna(ts):
+            out.append(None)
+        elif isinstance(ts, pd.Timestamp):
+            out.append(ts.to_pydatetime())
+        elif isinstance(ts, datetime):
+            out.append(ts)
+        else:
+            out.append(None)
+    return out
+
+
+def _coerce_equity_series(obj: Any) -> pd.Series | None:
+    series: pd.Series | None
+    if isinstance(obj, pd.Series):
+        series = obj.copy()
+    elif isinstance(obj, pd.DataFrame):
+        if "equity" in obj.columns:
+            series = obj["equity"].copy()
+        elif not obj.columns.empty:
+            series = obj.iloc[:, 0].copy()
+        else:
+            return None
+    else:
+        try:
+            series = pd.Series(obj)
+        except Exception:
+            return None
+
+    series = series.dropna()
+    if series.empty:
+        return None
+    series = series[~series.index.duplicated(keep="last")]
+    if not isinstance(series.index, pd.DatetimeIndex):
+        try:
+            series.index = pd.to_datetime(series.index, errors="coerce")
+        except Exception:
+            return None
+    series = series[~series.index.isna()].sort_index()
+    if series.empty:
+        return None
+    try:
+        series = series.astype(float)
+    except Exception:
+        return None
+    series = series.replace([np.inf, -np.inf], np.nan).dropna()
+    if series.empty:
+        return None
+    if isinstance(series.index, pd.DatetimeIndex) and series.index.tz is not None:
+        try:
+            series.index = series.index.tz_convert(None)
+        except Exception:
+            series.index = series.index.tz_localize(None)
+    return series.sort_index()
+
+
+def _align_benchmark_series(
+    raw_series: Any,
+    equity_series: pd.Series,
+    starting_equity: float,
+) -> pd.Series | None:
+    if raw_series is None:
+        return None
+    series = _coerce_equity_series(raw_series)
+    if series is None or series.empty:
+        return None
+
+    eq_index = equity_series.index
+    if not isinstance(eq_index, pd.DatetimeIndex):
+        return None
+
+    series = series.reindex(eq_index.union(series.index)).ffill().bfill()
+    series = series.reindex(eq_index).ffill().bfill()
+    series = series.replace([np.inf, -np.inf], np.nan).dropna()
+    if series.empty:
+        return None
+
+    try:
+        strategy_start = float(equity_series.iloc[0])
+    except Exception:
+        strategy_start = float(starting_equity)
+    if not np.isfinite(strategy_start) or abs(strategy_start) < 1e-9:
+        strategy_start = float(starting_equity)
+
+    bench_start = float(series.iloc[0])
+    if not np.isfinite(bench_start) or abs(bench_start) < 1e-12:
+        return None
+
+    scaled = (series / bench_start) * strategy_start
+    return scaled.reindex(eq_index)
+
+
+def _load_external_benchmark(
+    equity_series: pd.Series,
+    holdout_start: Any,
+    holdout_end: Any,
+    starting_equity: float,
+) -> pd.Series | None:
+    start_dt = _coerce_datetime(holdout_start) or equity_series.index.min()
+    end_dt = _coerce_datetime(holdout_end) or equity_series.index.max()
+    try:
+        series = get_benchmark_total_return(start=start_dt, end=end_dt)
+    except Exception:
+        series = None
+    if series is None or getattr(series, "empty", True):
+        return None
+    return _align_benchmark_series(series, equity_series, starting_equity)
+
+
 # ---- Holdout simulation -------------------------------------------------------
 
 def _simulate_holdout_equity(
@@ -107,20 +337,59 @@ def _simulate_holdout_equity(
     holdout_start: Any,
     holdout_end: Any,
     starting_equity: float,
-) -> Tuple[List[Any], List[float]]:
-    """Runs an out-of-sample (holdout) backtest for the given params and returns (x, y)."""
+) -> Dict[str, Any]:
+    """Runs an out-of-sample (holdout) backtest and returns curve metadata for plotting."""
+
+    result = _blank_curve()
     if not symbols:
-        return [], []
+        return result
 
     data = loader_fn(symbols=symbols, start=holdout_start, end=holdout_end)
     equity_df = engine_fn(params=params, data=data, starting_equity=starting_equity)
 
-    if not isinstance(equity_df, pd.DataFrame) or "equity" not in equity_df.columns:
-        return [], []
+    equity_series = None
+    benchmark_series: pd.Series | None = None
+    if isinstance(equity_df, pd.DataFrame):
+        equity_series = _coerce_equity_series(equity_df.get("equity", equity_df))
+        bench_candidates = [
+            col
+            for col in equity_df.columns
+            if str(col).lower() in {"benchmark", "benchmark_equity", "benchmark_ratio", "benchmark_total_return"}
+        ]
+        if bench_candidates:
+            benchmark_series = _align_benchmark_series(
+                equity_df[bench_candidates[0]],
+                equity_series if equity_series is not None else pd.Series(dtype=float),
+                starting_equity,
+            )
+    elif isinstance(equity_df, pd.Series):
+        equity_series = _coerce_equity_series(equity_df)
+    else:
+        return result
 
-    x = equity_df.index.tolist()
-    y = equity_df["equity"].astype(float).tolist()
-    return x, y
+    if equity_series is None or equity_series.empty:
+        return result
+
+    if benchmark_series is None:
+        benchmark_series = _load_external_benchmark(equity_series, holdout_start, holdout_end, starting_equity)
+
+    idx = equity_series.index
+    if isinstance(idx, pd.DatetimeIndex) and idx.tz is not None:
+        idx = idx.tz_convert(None)
+    x_values = idx.to_list()
+    equity_values = equity_series.astype(float).tolist()
+    benchmark_values = None
+    if benchmark_series is not None and not benchmark_series.empty:
+        bench_aligned = benchmark_series.reindex(equity_series.index).ffill().bfill()
+        if not bench_aligned.dropna().empty:
+            benchmark_values = bench_aligned.astype(float).tolist()
+
+    return {
+        "x": x_values,
+        "equity": equity_values,
+        "benchmark": benchmark_values,
+        "benchmark_label": "Benchmark",
+    }
 
 
 # ---- Public API ---------------------------------------------------------------
@@ -193,7 +462,7 @@ def on_generation_end(gen_idx: int, best_score: float, best_params: Dict[str, An
     if not cfg or placeholder is None:
         return
 
-    x, y = _simulate_holdout_equity(
+    curve = _simulate_holdout_equity(
         params=best_params,
         loader_fn=cfg.get("loader_fn"),
         engine_fn=cfg.get("engine_fn"),
@@ -202,11 +471,23 @@ def on_generation_end(gen_idx: int, best_score: float, best_params: Dict[str, An
         holdout_end=cfg.get("holdout_end"),
         starting_equity=cfg.get("starting_equity", 100_000.0),
     )
+    x = curve.get("x", [])
+    y = curve.get("equity", [])
     if not (x and y):
         return
 
     history = st.session_state.get(_ss_key("history"), [])
-    history.append({"gen": gen_idx, "x": x, "y": y, "label": f"Gen {gen_idx}", "score": best_score})
+    history.append(
+        {
+            "gen": gen_idx,
+            "x": x,
+            "equity": y,
+            "benchmark": curve.get("benchmark"),
+            "benchmark_label": curve.get("benchmark_label"),
+            "label": f"Gen {gen_idx}",
+            "score": best_score,
+        }
+    )
     max_curves = int(cfg.get("max_curves", 8))
     if len(history) > max_curves:
         history = history[-max_curves:]


### PR DESCRIPTION
## Summary
- render the holdout chart with benchmark overlays, out/under-performance shading, and descriptive legends
- add helpers to align benchmark data with strategy curves and persist benchmark metadata across generations

## Testing
- pytest tests/test_holdout_equity.py

------
https://chatgpt.com/codex/tasks/task_e_68e7c709dad8832a9cd113ddd01c5aa7