### PR TITLE
Fix warmup toggling for training and holdout paths

### DIFF
--- a/src/utils/holdout_chart.py
+++ b/src/utils/holdout_chart.py
@@ -7,6 +7,8 @@ import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
+from src.models._warmup import apply_disable_warmup_flag
+
 
 # ---- Internal state keys ------------------------------------------------------
 
@@ -269,7 +271,8 @@ def holdout_equity(
     if not strategy:
         return pd.DataFrame(columns=["date", "equity"])
 
-    params = params or {}
+    params_payload = apply_disable_warmup_flag(params, disable_warmup=False)
+    params_payload.setdefault("model_key", strategy)
     tickers = tickers or []
     if isinstance(tickers, str):
         tickers = [t.strip() for t in tickers.split(",") if t.strip()]
@@ -292,7 +295,13 @@ def holdout_equity(
     curves: Dict[str, pd.Series] = {}
     for sym in tickers:
         try:
-            result = run_strategy(sym, start_dt, end_dt, starting_equity, params)
+            result = run_strategy(
+                sym,
+                start_dt,
+                end_dt,
+                starting_equity,
+                dict(params_payload),
+            )
         except Exception:
             continue
 

--- a/tests/test_holdout_equity.py
+++ b/tests/test_holdout_equity.py
@@ -1,8 +1,9 @@
-import types
 from datetime import datetime
+import types
 
 import pandas as pd
 
+from src.models._warmup import DISABLE_WARMUP_FLAG
 from src.utils import holdout_chart
 
 
@@ -12,6 +13,7 @@ def _make_fake_module(equity_values):
     def _run_strategy(symbol, start, end, starting_equity, params):
         assert isinstance(start, datetime)
         assert isinstance(end, datetime)
+        assert DISABLE_WARMUP_FLAG not in params
         idx = pd.date_range(start=start, periods=len(equity_values), freq="D")
         series = pd.Series(equity_values, index=idx)
         return {


### PR DESCRIPTION
## Summary
- centralize warmup flag handling for Model Inspector strategy calls so training runs disable warmup and holdout runs enable it
- ensure the holdout equity utility always removes the disable-warmup flag before invoking strategy adapters
- add a regression test that asserts holdout simulations pass warmed parameters into strategy runners

## Testing
- pytest tests/test_holdout_equity.py tests/test_backtest_warmup.py

------
https://chatgpt.com/codex/tasks/task_e_68e7fcd78fac832a807e0374e71832cb