### PR TITLE
Document EA fitness weights and support commented config

### DIFF
--- a/docs/ea_fitness_weights_review.md
+++ b/docs/ea_fitness_weights_review.md
@@ -6,22 +6,36 @@
 - Editing the JSON by hand is the supported workflow for adjusting the evolutionary search behavior.
 
 ## Current Weight Configuration
+
+### Return Emphasis and Normalisation
 | Parameter | Value | Role |
 | --- | --- | --- |
-| `alpha_cagr` | 0.4835 | Weight on normalized CAGR (annualized growth). |
-| `beta_calmar` | 0.0011 | Weight on normalized Calmar ratio (drawdown sensitivity). |
-| `gamma_sharpe` | 0.0124 | Weight on normalized Sharpe ratio (risk-adjusted return). |
-| `delta_total_return` | 0.5029 | Weight on normalized total return. |
-| `calmar_cap` | 3.0 | Caps the normalized Calmar contribution. |
+| `use_normalized_scoring` | true | Enables metric normalisation so weight magnitudes map predictably to impact. |
+| `alpha_cagr` | 0.535 | Weight on normalized CAGR (annualised growth). |
+| `beta_calmar` | 0.11 | Weight on normalized Calmar ratio (drawdown sensitivity). |
+| `gamma_sharpe` | 0.124 | Weight on normalized Sharpe ratio (risk-adjusted return). |
+| `delta_total_return` | 0.4029 | Weight on normalized total return. |
+| `calmar_cap` | 3.0 | Caps the normalized Calmar contribution before weighting. |
+
+### Execution Discipline Penalties
+| Parameter | Value | Role |
+| --- | --- | --- |
 | `holding_penalty_weight` | 0.05 | Scales penalty for violating holding-period bounds. |
 | `trade_rate_penalty_weight` | 0.02 | Scales penalty for violating trade-rate band. |
-| `penalty_cap` | 0.15 | Maximum combined penalty deduction. |
+| `penalty_cap` | 0.45 | Maximum combined penalty deduction. |
+
+### Holding and Trade Bands
+| Parameter | Value | Role |
+| --- | --- | --- |
 | `min_holding_days` | 3.0 | Lower bound before incurring holding penalty. |
 | `max_holding_days` | 30.0 | Upper bound before incurring holding penalty. |
 | `trade_rate_min` | 5.0 | Lower bound before trade-rate penalty triggers. |
-| `trade_rate_max` | 50.0 | Upper bound threshold (currently inactive). |
+| `trade_rate_max` | 50.0 | Upper bound threshold when upper-band penalties are active. |
 | `rate_penalize_upper` | false | Disables penalties for exceeding `trade_rate_max`. |
-| `elite_by_return_frac` | 0.10 | Fraction of top performers kept by raw return during selection. |
+
+### Holdout Protection
+| Parameter | Value | Role |
+| --- | --- | --- |
 | `holdout_score_weight` | 0.65 | Blend weight for holdout/test metrics when both windows are available. |
 | `holdout_gap_tolerance` | 0.15 | Margin allowed before penalising train vs. test score gaps. |
 | `holdout_gap_penalty` | 0.50 | Penalty multiplier when the training score materially exceeds the holdout. |
@@ -32,12 +46,12 @@
 - **Risk weighting (`beta_calmar`, `gamma_sharpe`)**: Raising these values amplifies drawdown and volatility discipline; current near-zero Calmar weight makes drawdown control effectively irrelevant.
 - **Penalty weights and caps**: Higher `holding_penalty_weight` or `trade_rate_penalty_weight` quickly suppress rule-breaking strategies until the `penalty_cap` is reached; reducing the cap allows penalties to dominate faster.
 - **Band definitions**: Tightening `min_holding_days`/`max_holding_days` or `trade_rate_min`/`trade_rate_max` narrows acceptable behavior; enabling `rate_penalize_upper` enforces the upper trade-rate ceiling symmetrically.
-- **Elite fraction**: Larger `elite_by_return_frac` preserves more top-return solutions; shrinking it accelerates turnover and exploration.
+- **Elite fraction**: Survivor mixing is now governed strictly by the EA runtime parameters; the JSON config no longer overrides `elite_by_return_frac`.
 
 ## Observations & Recommendations
-1. **Return-heavy blend**: With nearly 1.0 combined weight on CAGR/total return, the search deprioritizes risk controls. Consider shifting 10–20% of the weight toward Sharpe and/or Calmar to balance risk-adjusted performance.
-2. **Calmar underweighting**: The `beta_calmar` weight (0.0011) is effectively negligible. If drawdown matters, raise it closer to Sharpe's weight or enforce a higher `calmar_cap` to reduce tolerance for deep losses.
-3. **Asymmetric trade penalties**: Because `rate_penalize_upper` is `false`, only under-trading is penalized. Enable the upper bound or increase `trade_rate_min` if over-trading is a concern.
-4. **Penalty slack**: The 0.15 `penalty_cap` combined with modest weights allows rule violations to persist. Tightening the cap or raising the weights will make holding/trade constraints more influential.
-5. **Holdout emphasis**: Raising `holdout_score_weight` pushes the EA toward pure holdout optimisation (weight→1.0) while lowering it reintroduces the in-sample score; tweak alongside the gap and shortfall penalties to keep overfitting in check.
-6. **Monitoring edits**: After manual adjustments, re-run the evolutionary search and review logged metric blends to verify the optimizer behaves as intended.
+1. **Return-heavy blend remains dominant**: CAGR and total return still represent ~94% of the total scoring weight, so risk ratios remain secondary. Rebalancing toward Sharpe/Calmar would align selection with drawdown tolerance.
+2. **Calmar is no longer negligible but still light**: Raising `beta_calmar` to 0.11 gives drawdown awareness, yet it trails Sharpe. Further increases or a lower `calmar_cap` would tighten downside control.
+3. **Penalty authority improved**: With `penalty_cap` at 0.45, the system can meaningfully suppress rule breakers, but the low penalty weights mean only repeated violations move the needle. Increase the weights if constraints must bite faster.
+4. **Upper trade rate still unchecked**: `rate_penalize_upper=false` leaves high-frequency behaviour unpenalised. Flip it to `true` or lower `trade_rate_max` if turnover is a concern.
+5. **Holdout blend encourages generalisation**: The 0.65 weight and paired penalties prioritise holdout integrity. Adjust all three holdout knobs in tandem when tuning to avoid overfitting back to the training window.
+6. **Documented JSON comments require compatible loaders**: Because the config now carries explanatory comments, ensure deployment paths use the repository loader (which strips comments) or mirror its preprocessing before parsing.

--- a/docs/ea_fitness_weights_review.md
+++ b/docs/ea_fitness_weights_review.md
@@ -2,12 +2,13 @@
 
 ## Storage and Load Behavior
 - Overrides are stored in `storage/config/ea_fitness.json` and consumed at runtime by the evolutionary fitness pipeline.
+- The JSON now nests related parameters by impact (return emphasis, penalties, bands, holdout) and the loader flattens them when applying overrides.
 - On startup, the optimizer reads this JSON, logs the applied parameters, and uses them when blending normalized objective metrics with capped penalties.
 - Editing the JSON by hand is the supported workflow for adjusting the evolutionary search behavior.
 
 ## Current Weight Configuration
 
-### Return Emphasis and Normalisation
+### Return Emphasis (`return_emphasis`)
 | Parameter | Value | Role |
 | --- | --- | --- |
 | `use_normalized_scoring` | true | Enables metric normalisation so weight magnitudes map predictably to impact. |
@@ -17,23 +18,26 @@
 | `delta_total_return` | 0.4029 | Weight on normalized total return. |
 | `calmar_cap` | 3.0 | Caps the normalized Calmar contribution before weighting. |
 
-### Execution Discipline Penalties
+### Execution Discipline Penalties (`execution_penalties`)
 | Parameter | Value | Role |
 | --- | --- | --- |
 | `holding_penalty_weight` | 0.05 | Scales penalty for violating holding-period bounds. |
 | `trade_rate_penalty_weight` | 0.02 | Scales penalty for violating trade-rate band. |
 | `penalty_cap` | 0.45 | Maximum combined penalty deduction. |
 
-### Holding and Trade Bands
+### Holding Window Preferences (`holding_windows`)
 | Parameter | Value | Role |
 | --- | --- | --- |
 | `min_holding_days` | 3.0 | Lower bound before incurring holding penalty. |
 | `max_holding_days` | 30.0 | Upper bound before incurring holding penalty. |
+### Trade Rate Band (`trade_rate_band`)
+| Parameter | Value | Role |
+| --- | --- | --- |
 | `trade_rate_min` | 5.0 | Lower bound before trade-rate penalty triggers. |
 | `trade_rate_max` | 50.0 | Upper bound threshold when upper-band penalties are active. |
 | `rate_penalize_upper` | false | Disables penalties for exceeding `trade_rate_max`. |
 
-### Holdout Protection
+### Holdout Protection (`holdout_protection`)
 | Parameter | Value | Role |
 | --- | --- | --- |
 | `holdout_score_weight` | 0.65 | Blend weight for holdout/test metrics when both windows are available. |
@@ -54,4 +58,4 @@
 3. **Penalty authority improved**: With `penalty_cap` at 0.45, the system can meaningfully suppress rule breakers, but the low penalty weights mean only repeated violations move the needle. Increase the weights if constraints must bite faster.
 4. **Upper trade rate still unchecked**: `rate_penalize_upper=false` leaves high-frequency behaviour unpenalised. Flip it to `true` or lower `trade_rate_max` if turnover is a concern.
 5. **Holdout blend encourages generalisation**: The 0.65 weight and paired penalties prioritise holdout integrity. Adjust all three holdout knobs in tandem when tuning to avoid overfitting back to the training window.
-6. **Documented JSON comments require compatible loaders**: Because the config now carries explanatory comments, ensure deployment paths use the repository loader (which strips comments) or mirror its preprocessing before parsing.
+6. **Grouped config keeps intent explicit**: We now organise the JSON into intent-based blocks (`return_emphasis`, `execution_penalties`, etc.). This structure helps reviewers tune related knobs together; ensure any downstream tools flatten nested keys the way the runtime loader does.

--- a/src/optimization/evolutionary.py
+++ b/src/optimization/evolutionary.py
@@ -100,6 +100,24 @@ def _strip_json_comments(text: str) -> str:
     return "".join(out)
 
 
+def _find_nested_value(data: Any, key: str, _sentinel: Any) -> Any:
+    """Return the first occurrence of ``key`` within a nested dict/list tree."""
+
+    if isinstance(data, dict):
+        if key in data:
+            return data[key]
+        for value in data.values():
+            result = _find_nested_value(value, key, _sentinel)
+            if result is not _sentinel:
+                return result
+    elif isinstance(data, list):
+        for value in data:
+            result = _find_nested_value(value, key, _sentinel)
+            if result is not _sentinel:
+                return result
+    return _sentinel
+
+
 def _load_fitness_config_json(path: Optional[str] = None) -> Dict[str, Any]:
     """
     Load fitness weight configuration from JSON. Returns {} if file missing or malformed.
@@ -122,36 +140,55 @@ def _load_fitness_config_json(path: Optional[str] = None) -> Dict[str, Any]:
         if not isinstance(data, dict):
             return {}
         out: Dict[str, Any] = {}
+        sentinel = object()
+
+        def _get_value(key: str) -> Any:
+            value = _find_nested_value(data, key, sentinel)
+            return None if value is sentinel else value
+
         # Copy only known keys with safe coercion
         def _getf(k: str):
             try:
-                return float(data[k])
+                value = _get_value(k)
+                if value is None:
+                    return None
+                return float(value)
             except Exception:
                 return None
-        if "alpha_cagr" in data: out["alpha_cagr"] = _getf("alpha_cagr")
-        if "beta_calmar" in data: out["beta_calmar"] = _getf("beta_calmar")
-        if "gamma_sharpe" in data: out["gamma_sharpe"] = _getf("gamma_sharpe")
-        if "delta_total_return" in data: out["delta_total_return"] = _getf("delta_total_return")
-        if "calmar_cap" in data: out["calmar_cap"] = _getf("calmar_cap")
-        if "use_normalized_scoring" in data:
-            v = data["use_normalized_scoring"]
-            out["use_normalized_scoring"] = bool(v) if isinstance(v, bool) else str(v).strip().lower() in {"1","true","yes","on"}
-        if "holding_penalty_weight" in data: out["holding_penalty_weight"] = _getf("holding_penalty_weight")
-        if "trade_rate_penalty_weight" in data: out["trade_rate_penalty_weight"] = _getf("trade_rate_penalty_weight")
-        if "penalty_cap" in data: out["penalty_cap"] = _getf("penalty_cap")
-        if "min_holding_days" in data: out["min_holding_days"] = _getf("min_holding_days")
-        if "max_holding_days" in data: out["max_holding_days"] = _getf("max_holding_days")
-        if "trade_rate_min" in data: out["trade_rate_min"] = _getf("trade_rate_min")
-        if "trade_rate_max" in data: out["trade_rate_max"] = _getf("trade_rate_max")
+        if _get_value("alpha_cagr") is not None: out["alpha_cagr"] = _getf("alpha_cagr")
+        if _get_value("beta_calmar") is not None: out["beta_calmar"] = _getf("beta_calmar")
+        if _get_value("gamma_sharpe") is not None: out["gamma_sharpe"] = _getf("gamma_sharpe")
+        if _get_value("delta_total_return") is not None: out["delta_total_return"] = _getf("delta_total_return")
+        if _get_value("calmar_cap") is not None: out["calmar_cap"] = _getf("calmar_cap")
+        norm_val = _get_value("use_normalized_scoring")
+        if norm_val is not None:
+            out["use_normalized_scoring"] = bool(norm_val) if isinstance(norm_val, bool) else str(norm_val).strip().lower() in {"1","true","yes","on"}
+        if _get_value("holding_penalty_weight") is not None:
+            out["holding_penalty_weight"] = _getf("holding_penalty_weight")
+        if _get_value("trade_rate_penalty_weight") is not None:
+            out["trade_rate_penalty_weight"] = _getf("trade_rate_penalty_weight")
+        if _get_value("penalty_cap") is not None:
+            out["penalty_cap"] = _getf("penalty_cap")
+        if _get_value("min_holding_days") is not None:
+            out["min_holding_days"] = _getf("min_holding_days")
+        if _get_value("max_holding_days") is not None:
+            out["max_holding_days"] = _getf("max_holding_days")
+        if _get_value("trade_rate_min") is not None:
+            out["trade_rate_min"] = _getf("trade_rate_min")
+        if _get_value("trade_rate_max") is not None:
+            out["trade_rate_max"] = _getf("trade_rate_max")
         # new optional keys
-        if "holdout_score_weight" in data: out["holdout_score_weight"] = _getf("holdout_score_weight")
-        if "holdout_gap_tolerance" in data: out["holdout_gap_tolerance"] = _getf("holdout_gap_tolerance")
-        if "holdout_gap_penalty" in data: out["holdout_gap_penalty"] = _getf("holdout_gap_penalty")
-        if "holdout_shortfall_penalty" in data:
+        if _get_value("holdout_score_weight") is not None:
+            out["holdout_score_weight"] = _getf("holdout_score_weight")
+        if _get_value("holdout_gap_tolerance") is not None:
+            out["holdout_gap_tolerance"] = _getf("holdout_gap_tolerance")
+        if _get_value("holdout_gap_penalty") is not None:
+            out["holdout_gap_penalty"] = _getf("holdout_gap_penalty")
+        if _get_value("holdout_shortfall_penalty") is not None:
             out["holdout_shortfall_penalty"] = _getf("holdout_shortfall_penalty")
-        if "rate_penalize_upper" in data:
-            v = data["rate_penalize_upper"]
-            out["rate_penalize_upper"] = bool(v) if isinstance(v, bool) else str(v).strip().lower() in {"1","true","yes","on"}
+        rate_upper_val = _get_value("rate_penalize_upper")
+        if rate_upper_val is not None:
+            out["rate_penalize_upper"] = bool(rate_upper_val) if isinstance(rate_upper_val, bool) else str(rate_upper_val).strip().lower() in {"1","true","yes","on"}
         # Drop any None-coerced floats
         for k in [
             "alpha_cagr","beta_calmar","gamma_sharpe","delta_total_return","calmar_cap",

--- a/storage/config/ea_fitness.json
+++ b/storage/config/ea_fitness.json
@@ -1,92 +1,30 @@
-// -----------------------------------------------------------------------------
-// Return-focused scoring weights. Increasing these tilt the EA toward high-growth
-// candidates, while reducing them frees capacity for risk or execution penalties.
-// -----------------------------------------------------------------------------
 {
-  // Normalize each metric before weighting so weights behave consistently.
-  "use_normalized_scoring": true,
-
-  // Higher values reward compounding annual growth; lower values downplay CAGR.
-  "alpha_cagr": 0.535,
-
-  // Raising this lifts the importance of capped drawdown-adjusted returns; lowering
-  // it tolerates deeper drawdowns if other metrics excel.
-  "beta_calmar": 0.11,
-
-  // Increasing this enforces steadier risk-adjusted performance; decreasing it lets
-  // volatile winners advance if total return stays high.
-  "gamma_sharpe": 0.124,
-
-  // Higher weight favors large absolute gains; reducing it shifts focus to ratios.
-  "delta_total_return": 0.4029,
-
-  // Lower caps tighten acceptable Calmar spikes; higher caps allow more upside from
-  // exceptional drawdown control before clipping.
-  "calmar_cap": 3.0,
-
-  // ---------------------------------------------------------------------------
-  // Execution discipline penalties. Raising weights or lowering the cap makes
-  // violations hurt sooner; easing them allows more rule-breaking before pruning.
-  // ---------------------------------------------------------------------------
-
-  // Stronger penalties push the EA away from too-short or too-long holding periods;
-  // weaker penalties let it explore more extreme durations.
-  "holding_penalty_weight": 0.05,
-
-  // Increasing this punishes trading too infrequently or too often; decreasing it
-  // lets turnover drift without heavy scoring impact.
-  "trade_rate_penalty_weight": 0.02,
-
-  // Lower caps apply penalty pressure aggressively; higher caps soften the maximum
-  // deduction from combined holding and trade violations.
-  "penalty_cap": 0.45,
-
-  // ---------------------------------------------------------------------------
-  // Preferred holding windows. Tightening bounds forces swing-trade behaviour;
-  // widening them embraces shorter scalps or longer trend holds.
-  // ---------------------------------------------------------------------------
-
-  // Raising the floor discourages quick exits; lowering it permits faster flips.
-  "min_holding_days": 3.0,
-
-  // Lower ceilings rein in prolonged positions; higher ceilings support trend riding.
-  "max_holding_days": 30.0,
-
-  // ---------------------------------------------------------------------------
-  // Preferred trade rate band. Narrow ranges make yearly trade cadence stricter;
-  // broad ranges invite experimentation.
-  // ---------------------------------------------------------------------------
-
-  // Increasing the minimum demands more trades per symbol; lowering it tolerates
-  // slower strategies before penalties kick in.
-  "trade_rate_min": 5.0,
-
-  // Lowering the maximum restrains hyperactive systems; raising it relaxes the
-  // ceiling when upper-band penalties are enabled.
-  "trade_rate_max": 50.0,
-
-  // When true, exceeding the upper trade rate is penalized; leaving it false keeps
-  // the focus on meeting the minimum cadence.
-  "rate_penalize_upper": false,
-
-  // ---------------------------------------------------------------------------
-  // Holdout protection. Increasing weights and penalties prioritizes generalization;
-  // easing them accepts greater divergence between train and test scores.
-  // ---------------------------------------------------------------------------
-
-  // Higher blend weight leans the EA toward holdout metrics; lower weight rebalances
-  // toward in-sample performance when both sets exist.
-  "holdout_score_weight": 0.65,
-
-  // Tight tolerances flag smaller gaps between train and test; wider tolerances
-  // forgive more separation before penalties apply.
-  "holdout_gap_tolerance": 0.15,
-
-  // Raising the penalty clamps down on cases where training outperforms holdout;
-  // lowering it softens overfitting deterrence.
-  "holdout_gap_penalty": 0.50,
-
-  // Higher values punish holdout underperformance more severely; lower values allow
-  // promising training results to persist despite softer holdout scores.
-  "holdout_shortfall_penalty": 0.35
+  "return_emphasis": {
+    "use_normalized_scoring": true,
+    "alpha_cagr": 0.535,
+    "beta_calmar": 0.11,
+    "gamma_sharpe": 0.124,
+    "delta_total_return": 0.4029,
+    "calmar_cap": 3.0
+  },
+  "execution_penalties": {
+    "holding_penalty_weight": 0.05,
+    "trade_rate_penalty_weight": 0.02,
+    "penalty_cap": 0.45
+  },
+  "holding_windows": {
+    "min_holding_days": 3.0,
+    "max_holding_days": 30.0
+  },
+  "trade_rate_band": {
+    "trade_rate_min": 5.0,
+    "trade_rate_max": 50.0,
+    "rate_penalize_upper": false
+  },
+  "holdout_protection": {
+    "holdout_score_weight": 0.65,
+    "holdout_gap_tolerance": 0.15,
+    "holdout_gap_penalty": 0.50,
+    "holdout_shortfall_penalty": 0.35
+  }
 }

--- a/storage/config/ea_fitness.json
+++ b/storage/config/ea_fitness.json
@@ -1,27 +1,92 @@
+// -----------------------------------------------------------------------------
+// Return-focused scoring weights. Increasing these tilt the EA toward high-growth
+// candidates, while reducing them frees capacity for risk or execution penalties.
+// -----------------------------------------------------------------------------
 {
+  // Normalize each metric before weighting so weights behave consistently.
   "use_normalized_scoring": true,
 
+  // Higher values reward compounding annual growth; lower values downplay CAGR.
   "alpha_cagr": 0.535,
+
+  // Raising this lifts the importance of capped drawdown-adjusted returns; lowering
+  // it tolerates deeper drawdowns if other metrics excel.
   "beta_calmar": 0.11,
+
+  // Increasing this enforces steadier risk-adjusted performance; decreasing it lets
+  // volatile winners advance if total return stays high.
   "gamma_sharpe": 0.124,
+
+  // Higher weight favors large absolute gains; reducing it shifts focus to ratios.
   "delta_total_return": 0.4029,
+
+  // Lower caps tighten acceptable Calmar spikes; higher caps allow more upside from
+  // exceptional drawdown control before clipping.
   "calmar_cap": 3.0,
 
+  // ---------------------------------------------------------------------------
+  // Execution discipline penalties. Raising weights or lowering the cap makes
+  // violations hurt sooner; easing them allows more rule-breaking before pruning.
+  // ---------------------------------------------------------------------------
+
+  // Stronger penalties push the EA away from too-short or too-long holding periods;
+  // weaker penalties let it explore more extreme durations.
   "holding_penalty_weight": 0.05,
+
+  // Increasing this punishes trading too infrequently or too often; decreasing it
+  // lets turnover drift without heavy scoring impact.
   "trade_rate_penalty_weight": 0.02,
+
+  // Lower caps apply penalty pressure aggressively; higher caps soften the maximum
+  // deduction from combined holding and trade violations.
   "penalty_cap": 0.45,
 
+  // ---------------------------------------------------------------------------
+  // Preferred holding windows. Tightening bounds forces swing-trade behaviour;
+  // widening them embraces shorter scalps or longer trend holds.
+  // ---------------------------------------------------------------------------
+
+  // Raising the floor discourages quick exits; lowering it permits faster flips.
   "min_holding_days": 3.0,
+
+  // Lower ceilings rein in prolonged positions; higher ceilings support trend riding.
   "max_holding_days": 30.0,
 
+  // ---------------------------------------------------------------------------
+  // Preferred trade rate band. Narrow ranges make yearly trade cadence stricter;
+  // broad ranges invite experimentation.
+  // ---------------------------------------------------------------------------
+
+  // Increasing the minimum demands more trades per symbol; lowering it tolerates
+  // slower strategies before penalties kick in.
   "trade_rate_min": 5.0,
+
+  // Lowering the maximum restrains hyperactive systems; raising it relaxes the
+  // ceiling when upper-band penalties are enabled.
   "trade_rate_max": 50.0,
+
+  // When true, exceeding the upper trade rate is penalized; leaving it false keeps
+  // the focus on meeting the minimum cadence.
   "rate_penalize_upper": false,
 
-  "elite_by_return_frac": 0.10,
+  // ---------------------------------------------------------------------------
+  // Holdout protection. Increasing weights and penalties prioritizes generalization;
+  // easing them accepts greater divergence between train and test scores.
+  // ---------------------------------------------------------------------------
 
+  // Higher blend weight leans the EA toward holdout metrics; lower weight rebalances
+  // toward in-sample performance when both sets exist.
   "holdout_score_weight": 0.65,
+
+  // Tight tolerances flag smaller gaps between train and test; wider tolerances
+  // forgive more separation before penalties apply.
   "holdout_gap_tolerance": 0.15,
+
+  // Raising the penalty clamps down on cases where training outperforms holdout;
+  // lowering it softens overfitting deterrence.
   "holdout_gap_penalty": 0.50,
+
+  // Higher values punish holdout underperformance more severely; lower values allow
+  // promising training results to persist despite softer holdout scores.
   "holdout_shortfall_penalty": 0.35
 }


### PR DESCRIPTION
## Summary
- allow the EA fitness config loader to strip inline and block comments before JSON parsing and fall back when disable_warmup is unsupported
- document grouping of return, penalty, band, and holdout weights in the review doc while noting elite fraction is controlled by EA runtime knobs
- reorganize storage/config/ea_fitness.json with annotated sections for each weight and remove the elite_by_return_frac override

## Testing
- pytest tests/test_evolutionary_config.py

------
https://chatgpt.com/codex/tasks/task_e_68e8041c10a8832a8547d2fe9612ea8d